### PR TITLE
Bring across a number of fixes based on input from Hargrove and extensive testing of direct modex support

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -437,6 +437,16 @@ typedef struct {
         }                                               \
     } while(0);
 
+/* expose a function that is resolved in the
+ * PMIx library, but part of a header that
+ * includes internal functions - so we don't
+ * want to expose the entire header here
+ */
+extern void pmix_value_load(pmix_value_t *v, void *data,
+                            pmix_data_type_t type);
+
+
+
 
 /****    PMIX INFO STRUCT    ****/
 typedef struct {

--- a/man/pmix_constants.7.md
+++ b/man/pmix_constants.7.md
@@ -72,20 +72,6 @@ A list of the current PMIx attributes, and the type of their associated data val
 *PMIX_ERROR*
 : A general error code - an error occurred, but no specific reason can be provided.
 
-*fi_rma - Remote Memory Access*
-: RMA transfers are one-sided operations that read or write data
-  directly to a remote memory region.  Other than defining the
-  appropriate memory region, RMA operations do not require interaction
-  at the target side for the data transfer to complete.
-
-*fi_atomic - Atomic*
-: Atomic operations can perform one of several operations on a remote
-  memory region.  Atomic operations include well-known functionality,
-  such as atomic-add and compare-and-swap, plus several other
-  pre-defined calls.  Unlike other data transfer interfaces, atomic
-  operations are aware of the data formatting at the target memory
-  region.
-
 
 # SEE ALSO
 

--- a/src/buffer_ops/buffer_ops.h
+++ b/src/buffer_ops/buffer_ops.h
@@ -68,6 +68,8 @@ PMIX_DECLSPEC pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
         (b)->bytes_allocated = (s);                     \
         (b)->pack_ptr = ((char*)(b)->base_ptr) + (s);   \
         (b)->unpack_ptr = (b)->base_ptr;                \
+        (d) = NULL;                                     \
+        (s) = 0;                                        \
     } while(0);
 
 #define PMIX_UNLOAD_BUFFER(b, d, s)             \

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -228,16 +228,14 @@ int PMIx_Init(pmix_proc_t *proc)
     pmix_nspace_t *nsptr;
     pmix_cb_t cb;
 
-    if (NULL == proc) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-
     if (0 < pmix_globals.init_cntr) {
         /* since we have been called before, the nspace and
          * rank should be known. So return them here if
          * requested */
-        (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
-        proc->rank = pmix_globals.myid.rank;
+        if (NULL != proc) {
+            (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+            proc->rank = pmix_globals.myid.rank;
+        }
         return PMIX_SUCCESS;
     }
 
@@ -281,7 +279,9 @@ int PMIx_Init(pmix_proc_t *proc)
         pmix_class_finalize();
         return PMIX_ERR_INVALID_NAMESPACE;
     }
-    (void)strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
+    if (NULL != proc) {
+        (void)strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
+    }
     (void)strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
     nsptr = PMIX_NEW(pmix_nspace_t);
     (void)strncpy(nsptr->nspace, evar, PMIX_MAX_NSLEN);
@@ -336,7 +336,9 @@ int PMIx_Init(pmix_proc_t *proc)
         return PMIX_ERR_DATA_VALUE_NOT_FOUND;
     }
     pmix_globals.myid.rank = strtol(evar, NULL, 10);
-    proc->rank = pmix_globals.myid.rank;
+    if (NULL != proc) {
+        proc->rank = pmix_globals.myid.rank;
+    }
     pmix_globals.pindex = -1;
 
     /* setup the support */
@@ -530,11 +532,69 @@ int PMIx_Abort(int flag, const char msg[],
     return PMIX_SUCCESS;
 }
 
-pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
+static void _putfn(int sd, short args, void *cbdata)
 {
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     pmix_status_t rc;
     pmix_kval_t *kv;
     pmix_nspace_t *ns;
+
+    /* setup to xfer the data */
+    kv = PMIX_NEW(pmix_kval_t);
+    kv->key = strdup(cb->key);  // need to copy as the input belongs to the user
+    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    rc = pmix_value_xfer(kv->value, cb->value);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
+    /* put it in our own modex hash table in case something
+     * internal to us wants it - our nsrecord is always
+     * first on the list */
+    if (NULL == (ns = (pmix_nspace_t*)pmix_list_get_first(&pmix_globals.nspaces))) {
+        /* shouldn't be possible */
+        goto done;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_hash_store(&ns->modex, pmix_globals.myid.rank, kv))) {
+        PMIX_ERROR_LOG(rc);
+    }
+
+    /* pack the cache that matches the scope - global scope needs
+     * to go into both local and remote caches */
+    if (PMIX_LOCAL == cb->scope || PMIX_GLOBAL == cb->scope) {
+        if (NULL == pmix_globals.cache_local) {
+            pmix_globals.cache_local = PMIX_NEW(pmix_buffer_t);
+        }
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix: put %s data for key %s in local cache",
+                            cb->key, (PMIX_GLOBAL == cb->scope) ? "global" : "local");
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(pmix_globals.cache_local, kv, 1, PMIX_KVAL))) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+
+    if (PMIX_REMOTE == cb->scope || PMIX_GLOBAL == cb->scope) {
+        if (NULL == pmix_globals.cache_remote) {
+            pmix_globals.cache_remote = PMIX_NEW(pmix_buffer_t);
+        }
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix: put %s data for key %s in remote cache",
+                            cb->key, (PMIX_GLOBAL == cb->scope) ? "global" : "remote");
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(pmix_globals.cache_remote, kv, 1, PMIX_KVAL))) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+
+  done:
+    PMIX_RELEASE(kv);  // maintain accounting
+    cb->pstatus = rc;
+    cb->active = false;
+}
+
+pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
+{
+    pmix_cb_t *cb;
+    pmix_status_t rc;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: executing put for key %s type %d",
@@ -544,65 +604,84 @@ pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
         return PMIX_ERR_INIT;
     }
 
-    /* setup to xfer the data */
-    kv = PMIX_NEW(pmix_kval_t);
-    kv->key = strdup((char*)key);
-    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-    rc = pmix_value_xfer(kv->value, val);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(kv);
-        return rc;
-    }
-    /* put it in our own modex hash table in case something
-     * internal to us wants it - our nsrecord is always
-     * first on the list */
-    if (NULL == (ns = (pmix_nspace_t*)pmix_list_get_first(&pmix_globals.nspaces))) {
-        /* shouldn't be possible */
-        PMIX_RELEASE(kv);
-        return PMIX_ERR_INIT;
-    }
-    if (PMIX_SUCCESS != (rc = pmix_hash_store(&ns->modex, pmix_globals.myid.rank, kv))) {
-        PMIX_ERROR_LOG(rc);
-    }
+    /* create a callback object */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->active = true;
+    cb->scope = scope;
+    cb->key = (char*)key;
+    cb->value = val;
 
-    /* pack the cache that matches the scope - global scope needs
-     * to go into both local and remote caches */
-    if (PMIX_LOCAL == scope || PMIX_GLOBAL == scope) {
-        if (NULL == pmix_globals.cache_local) {
-            pmix_globals.cache_local = PMIX_NEW(pmix_buffer_t);
-        }
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix: put %s data for key %s in local cache",
-                            key, (PMIX_GLOBAL == scope) ? "global" : "local");
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(pmix_globals.cache_local, kv, 1, PMIX_KVAL))) {
-            PMIX_ERROR_LOG(rc);
-        }
-    }
+    /* pass this into the event library for thread protection */
+    PMIX_THREAD_SHIFT(cb, _putfn);
 
-    if (PMIX_REMOTE == scope || PMIX_GLOBAL == scope) {
-        if (NULL == pmix_globals.cache_remote) {
-            pmix_globals.cache_remote = PMIX_NEW(pmix_buffer_t);
-        }
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix: put %s data for key %s in remote cache",
-                            key, (PMIX_GLOBAL == scope) ? "global" : "remote");
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(pmix_globals.cache_remote, kv, 1, PMIX_KVAL))) {
-            PMIX_ERROR_LOG(rc);
-        }
-    }
-
-    PMIX_RELEASE(kv);  // maintain accounting
+    /* wait for the result */
+    PMIX_WAIT_FOR_COMPLETION(cb->active);
+    rc = cb->pstatus;
+    PMIX_RELEASE(cb);
 
     return rc;
 }
 
-pmix_status_t PMIx_Commit(void)
+static void _commitfn(int sd, short args, void *cbdata)
 {
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     pmix_status_t rc;
     pmix_scope_t scope;
     pmix_buffer_t *msgout;
     pmix_cmd_t cmd=PMIX_COMMIT_CMD;
+
+    msgout = PMIX_NEW(pmix_buffer_t);
+    /* pack the cmd */
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &cmd, 1, PMIX_CMD))) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msgout);
+        goto done;
+    }
+
+    /* if we haven't already done it, ensure we have committed our values */
+    if (NULL != pmix_globals.cache_local) {
+        scope = PMIX_LOCAL;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &scope, 1, PMIX_SCOPE))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msgout);
+            goto done;
+        }
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &pmix_globals.cache_local, 1, PMIX_BUFFER))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msgout);
+            goto done;
+        }
+        PMIX_RELEASE(pmix_globals.cache_local);
+    }
+    if (NULL != pmix_globals.cache_remote) {
+        scope = PMIX_REMOTE;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &scope, 1, PMIX_SCOPE))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msgout);
+            goto done;
+        }
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &pmix_globals.cache_remote, 1, PMIX_BUFFER))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msgout);
+            goto done;
+        }
+        PMIX_RELEASE(pmix_globals.cache_remote);
+    }
+
+    /* push the message into our event base to send to the server - always
+     * send, even if we have nothing to contribute, so the server knows
+     * that we contributed whatever we had */
+    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msgout, NULL, NULL);
+
+  done:
+    cb->pstatus = rc;
+    cb->active = false;
+}
+
+pmix_status_t PMIx_Commit(void)
+{
+    pmix_cb_t *cb;
+    pmix_status_t rc;
 
     /* if we are a server, or we aren't connected, don't attempt to send */
     if (pmix_globals.server) {
@@ -612,70 +691,37 @@ pmix_status_t PMIx_Commit(void)
         return PMIX_ERR_UNREACH;
     }
 
-    msgout = PMIX_NEW(pmix_buffer_t);
-    /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &cmd, 1, PMIX_CMD))) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE(msgout);
-        return rc;
-    }
+    /* create a callback object */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->active = true;
 
-    /* if we haven't already done it, ensure we have committed our values */
-    if (NULL != pmix_globals.cache_local) {
-        scope = PMIX_LOCAL;
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &scope, 1, PMIX_SCOPE))) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msgout);
-            return rc;
-        }
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &pmix_globals.cache_local, 1, PMIX_BUFFER))) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msgout);
-            return rc;
-        }
-        PMIX_RELEASE(pmix_globals.cache_local);
-    }
-    if (NULL != pmix_globals.cache_remote) {
-        scope = PMIX_REMOTE;
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &scope, 1, PMIX_SCOPE))) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msgout);
-            return rc;
-        }
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &pmix_globals.cache_remote, 1, PMIX_BUFFER))) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msgout);
-            return rc;
-        }
-        PMIX_RELEASE(pmix_globals.cache_remote);
-    }
+    /* pass this into the event library for thread protection */
+    PMIX_THREAD_SHIFT(cb, _commitfn);
 
-    /* push the message into our event base to send to the server - always
-     * send, even if we have nothing to contribute, so the server knows
-     * that we contributed whatever we had */
-    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msgout, NULL, NULL);
-    return PMIX_SUCCESS;
+    /* wait for the result */
+    PMIX_WAIT_FOR_COMPLETION(cb->active);
+    rc = cb->pstatus;
+    PMIX_RELEASE(cb);
+
+    return rc;
 }
 
-pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
-                                 pmix_proc_t **procs, size_t *nprocs)
+static void _peersfn(int sd, short args, void *cbdata)
 {
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    pmix_status_t rc;
     char **nsprocs=NULL, **nsps=NULL, **tmp;
     pmix_nspace_t *nsptr;
     pmix_nrec_t *nptr;
     size_t i;
 
-    /* set the default */
-    *procs = NULL;
-    *nprocs = 0;
-
     /* cycle across our known nspaces */
     tmp = NULL;
     PMIX_LIST_FOREACH(nsptr, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (NULL == nspace || 0 == strcmp(nsptr->nspace, nspace)) {
+        if (0 == strncmp(nsptr->nspace, cb->nspace, PMIX_MAX_NSLEN)) {
             /* cycle across the nodes in this nspace */
             PMIX_LIST_FOREACH(nptr, &nsptr->nodes, pmix_nrec_t) {
-                if (0 == strcmp(nodename, nptr->name)) {
+                if (0 == strcmp(cb->key, nptr->name)) {
                     /* add the contribution from this node */
                     tmp = pmix_argv_split(nptr->procs, ',');
                     for (i=0; NULL != tmp[i]; i++) {
@@ -689,41 +735,71 @@ pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
         }
     }
     if (0 == (i = pmix_argv_count(nsps))) {
-        /* if we don't already have a record for this nspace,
-         * see if we have the data in our local cache */
-
-        return PMIX_ERR_NOT_FOUND;
+        /* we don't know this nspace */
+        rc = PMIX_ERR_NOT_FOUND;
+        goto done;
     }
 
     /* create the required storage */
-    i = pmix_argv_count(nsps);
-    PMIX_PROC_CREATE(*procs, i);
-    *nprocs = pmix_argv_count(nsps);
+    PMIX_PROC_CREATE(cb->procs, i);
+    cb->nvals = pmix_argv_count(nsps);
 
     /* transfer the data */
     for (i=0; NULL != nsps[i]; i++) {
-        (void)strncpy((*procs)[i].nspace, nsps[i], PMIX_MAX_NSLEN);
-        (*procs)[i].rank = strtol(nsprocs[i], NULL, 10);
+        (void)strncpy(cb->procs[i].nspace, nsps[i], PMIX_MAX_NSLEN);
+        cb->procs[i].rank = strtol(nsprocs[i], NULL, 10);
     }
     pmix_argv_free(nsps);
     pmix_argv_free(nsprocs);
+    rc = PMIX_SUCCESS;
 
-    return PMIX_SUCCESS;
+  done:
+    cb->pstatus = rc;
+    cb->active = false;
 }
 
-pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist)
+pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
+                                 pmix_proc_t **procs, size_t *nprocs)
 {
+    pmix_cb_t *cb;
+    pmix_status_t rc;
+
+    /* create a callback object */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->active = true;
+    cb->key = (char*)nodename;
+    if (NULL != nspace) {
+        (void)strncpy(cb->nspace, nspace, PMIX_MAX_NSLEN);
+    }
+
+    /* pass this into the event library for thread protection */
+    PMIX_THREAD_SHIFT(cb, _peersfn);
+
+    /* wait for the result */
+    PMIX_WAIT_FOR_COMPLETION(cb->active);
+    rc = cb->pstatus;
+    /* transfer the result */
+    *procs = cb->procs;
+    *nprocs = cb->nvals;
+
+    /* cleanup */
+    PMIX_RELEASE(cb);
+
+    return rc;
+}
+
+static void _nodesfn(int sd, short args, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    pmix_status_t rc;
     char **tmp;
     pmix_nspace_t *nsptr;
     pmix_nrec_t *nptr;
 
-    /* set the default */
-    *nodelist = NULL;
-
     /* cycle across our known nspaces */
     tmp = NULL;
     PMIX_LIST_FOREACH(nsptr, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (NULL == nspace || 0 == strcmp(nsptr->nspace, nspace)) {
+        if (0 == strncmp(nsptr->nspace, cb->nspace, PMIX_MAX_NSLEN)) {
             /* cycle across the nodes in this nspace */
             PMIX_LIST_FOREACH(nptr, &nsptr->nodes, pmix_nrec_t) {
                 pmix_argv_append_unique_nosize(&tmp, nptr->name, false);
@@ -731,11 +807,39 @@ pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist)
         }
     }
     if (NULL == tmp) {
-        return PMIX_ERR_NOT_FOUND;
+        rc = PMIX_ERR_NOT_FOUND;
+    } else {
+        cb->key = pmix_argv_join(tmp, ',');
+        pmix_argv_free(tmp);
+        rc = PMIX_SUCCESS;
     }
-    *nodelist = pmix_argv_join(tmp, ',');
-    pmix_argv_free(tmp);
-    return PMIX_SUCCESS;
+
+    cb->pstatus = rc;
+    cb->active = false;
+}
+
+pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist)
+{
+    pmix_cb_t *cb;
+    pmix_status_t rc;
+
+    /* create a callback object */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->active = true;
+    if (NULL != nspace) {
+        (void)strncpy(cb->nspace, nspace, PMIX_MAX_NSLEN);
+    }
+
+    /* pass this into the event library for thread protection */
+    PMIX_THREAD_SHIFT(cb, _nodesfn);
+
+    /* wait for the result */
+    PMIX_WAIT_FOR_COMPLETION(cb->active);
+    rc = cb->pstatus;
+    *nodelist = cb->key;
+    PMIX_RELEASE(cb);
+
+    return rc;
 }
 
 
@@ -919,9 +1023,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* protect the data */
-            kptr->value->data.bo.bytes = NULL;
-            kptr->value->data.bo.size = 0;
             PMIX_RELEASE(kptr);
             /* start by unpacking the rank */
             cnt = 1;
@@ -958,9 +1059,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* protect the data */
-            kptr->value->data.bo.bytes = NULL;
-            kptr->value->data.bo.size = 0;
             PMIX_RELEASE(kptr);
             /* start by unpacking the number of nodes */
             cnt = 1;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -59,9 +59,12 @@
 static pmix_buffer_t* pack_get(char *nspace, int rank,
                                const pmix_info_t info[], size_t ninfo,
                                pmix_cmd_t cmd);
+
+static void _getnbfn(int sd, short args, void *cbdata);
+
 static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata);
-static void getnb_shortcut(int fd, short flags, void *cbdata);
+
 static void value_cbfunc(int status, pmix_value_t *kv, void *cbdata);
 
 int PMIx_Get(const pmix_proc_t *proc, const char key[],
@@ -90,10 +93,8 @@ int PMIx_Get(const pmix_proc_t *proc, const char key[],
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
     cb->active = true;
-
     if (PMIX_SUCCESS != (rc = PMIx_Get_nb(proc, key, info, ninfo, value_cbfunc, cb))) {
         PMIX_RELEASE(cb);
-        *val = NULL;
         return rc;
     }
 
@@ -113,13 +114,7 @@ pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
                           const pmix_info_t info[], size_t ninfo,
                           pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_value_t *val;
-    pmix_buffer_t *msg;
     pmix_cb_t *cb;
-    pmix_status_t rc;
-    char *nm;
-    pmix_nspace_t *ns, *nptr;
-    size_t n;
 
     if (NULL == proc) {
         return PMIX_ERR_BAD_PARAM;
@@ -139,184 +134,18 @@ pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
         return PMIX_ERR_BAD_PARAM;
     }
 
-    /* if the nspace is empty, then the caller is referencing
-     * our own nspace */
-    if (0 == strlen(proc->nspace)) {
-        nm = pmix_globals.myid.nspace;
-    } else {
-        nm = (char*)proc->nspace;
-    }
-
-    /* find the nspace object */
-    nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (0 == strcmp(nm, ns->nspace)) {
-            nptr = ns;
-            break;
-        }
-    }
-    if (NULL == nptr) {
-        /* we are asking for info about a new nspace - give us
-         * a chance to learn about it from the server. If the
-         * server has never heard of it, the server will return
-         * an error */
-         nptr = PMIX_NEW(pmix_nspace_t);
-         (void)strncpy(nptr->nspace, nm, PMIX_MAX_NSLEN);
-         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
-         /* there is no point in looking for data in this nspace
-          * object, so let's just go generate the request */
-         goto request;
-    }
-
-    /* the requested data could be in the job-data table, so let's
-     * just check there first.  */
-    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, PMIX_RANK_WILDCARD, key, &val))) {
-        /* found it - return it via appropriate channel */
-        cb = PMIX_NEW(pmix_cb_t);
-        (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
-        cb->rank = proc->rank;
-        cb->key = strdup(key);
-        cb->value_cbfunc = cbfunc;
-        cb->cbdata = cbdata;
-        /* pack the return data so the unpack routine can get it */
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&cb->data, val, 1, PMIX_VALUE))) {
-            PMIX_ERROR_LOG(rc);
-        }
-        /* cleanup */
-        if (NULL != val) {
-            PMIX_VALUE_RELEASE(val);
-        }
-        /* activate the event */
-        event_assign(&(cb->ev), pmix_globals.evbase, -1,
-                     EV_WRITE, getnb_shortcut, cb);
-        event_active(&(cb->ev), EV_WRITE, 1);
-        return PMIX_SUCCESS;
-    }
-    if (PMIX_RANK_WILDCARD == proc->rank) {
-        /* can't be anywhere else */
-        return PMIX_ERR_NOT_FOUND;
-    }
-
-    /* it could still be in the job-data table, only stored under its own
-     * rank and not WILDCARD - e.g., this is true of data returned about
-     * ourselves during startup */
-    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, proc->rank, key, &val))) {
-        /* found it - return it via appropriate channel */
-        cb = PMIX_NEW(pmix_cb_t);
-        (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
-        cb->rank = proc->rank;
-        cb->key = strdup(key);
-        cb->value_cbfunc = cbfunc;
-        cb->cbdata = cbdata;
-        /* pack the return data so the unpack routine can get it */
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&cb->data, val, 1, PMIX_VALUE))) {
-            PMIX_ERROR_LOG(rc);
-        }
-        /* cleanup */
-        if (NULL != val) {
-            PMIX_VALUE_RELEASE(val);
-        }
-        /* activate the event */
-        event_assign(&(cb->ev), pmix_globals.evbase, -1,
-                     EV_WRITE, getnb_shortcut, cb);
-        event_active(&(cb->ev), EV_WRITE, 1);
-        return PMIX_SUCCESS;
-    }
-
-    /* not finding it is not an error - it could be in the
-     * modex hash table, so check it */
-    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->modex, proc->rank, key, &val))) {
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix: value retrieved from dstore");
-        /* need to push this into the event library to ensure
-         * the callback occurs within an event */
-        cb = PMIX_NEW(pmix_cb_t);
-        (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
-        cb->rank = proc->rank;
-        cb->key = strdup(key);
-        cb->value_cbfunc = cbfunc;
-        cb->cbdata = cbdata;
-        /* pack the return data so the unpack routine can get it */
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&cb->data, val, 1, PMIX_VALUE))) {
-            PMIX_ERROR_LOG(rc);
-        }
-        /* cleanup */
-        if (NULL != val) {
-            PMIX_VALUE_RELEASE(val);
-        }
-        /* activate the event */
-        event_assign(&(cb->ev), pmix_globals.evbase, -1,
-                     EV_WRITE, getnb_shortcut, cb);
-        event_active(&(cb->ev), EV_WRITE, 1);
-        return PMIX_SUCCESS;
-    } else if (PMIX_ERR_NOT_FOUND == rc) {
-        /* we have the modex data from this proc, but didn't find the key
-         * the user requested. At this time, there is no way for the
-         * key to eventually be found, so all we can do is return
-         * the error */
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "Error requesting key=%s for rank = %d, namespace = %s",
-                            key, proc->rank, nm);
-        return rc;
-    }
-
-  request:
-    /* if we got here, then we don't have the data for this proc. If we
-     * are a server, or we are a client and not connected, then there is
-     * nothing more we can do */
-    if (pmix_globals.server || (!pmix_globals.server && !pmix_globals.connected)) {
-        return PMIX_ERR_NOT_FOUND;
-    }
-
-    /* we also have to check the user's directives to see if they do not want
-     * us to attempt to retrieve it from the server */
-    for (n=0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, PMIX_OPTIONAL) &&
-            info[n].value.data.flag) {
-            /* they don't want us to try and retrieve it */
-            pmix_output_verbose(2, pmix_globals.debug_output,
-                                "PMIx_Get key=%s for rank = %d, namespace = %s was not found - request was optional",
-                                key, proc->rank, nm);
-            return PMIX_ERR_NOT_FOUND;
-        }
-    }
-    /* see if we already have a request in place with the server for data from
-     * this nspace:rank. If we do, then no need to ask again as the
-     * request will return _all_ data from that proc */
-    PMIX_LIST_FOREACH(cb, &pmix_client_globals.pending_requests, pmix_cb_t) {
-        if (0 == strncmp(nm, cb->nspace, PMIX_MAX_NSLEN) && cb->rank == proc->rank) {
-            /* we do have a pending request, but we still need to track this
-             * outstanding request so we can satisfy it once the data is returned */
-            cb = PMIX_NEW(pmix_cb_t);
-            (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
-            cb->rank = proc->rank;
-            cb->key = strdup(key);
-            cb->value_cbfunc = cbfunc;
-            cb->cbdata = cbdata;
-            pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
-            return PMIX_SUCCESS;
-        }
-    }
-
-    /* we don't have a pending request, so let's create one - don't worry
-     * about packing the key as we return everything from that proc */
-    if (NULL == (msg = pack_get(nm, proc->rank, info, ninfo, PMIX_GETNB_CMD))) {
-        return PMIX_ERROR;
-    }
-
-    /* create a callback object as we need to pass it to the
-     * recv routine so we know which callback to use when
-     * the return message is recvd */
+    /* thread-shift so we can check global objects */
     cb = PMIX_NEW(pmix_cb_t);
-    (void)strncpy(cb->nspace, nm, PMIX_MAX_NSLEN);
+    cb->active = true;
+    (void)strncpy(cb->nspace, proc->nspace, PMIX_MAX_NSLEN);
     cb->rank = proc->rank;
-    cb->key = strdup(key);
+    cb->key = (char*)key;
+    cb->info = (pmix_info_t*)info;
+    cb->ninfo = ninfo;
     cb->value_cbfunc = cbfunc;
     cb->cbdata = cbdata;
-    pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
+    PMIX_THREAD_SHIFT(cb, _getnbfn);
 
-    /* push the message into our event base to send to the server */
-    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msg, getnb_cbfunc, cb);
     return PMIX_SUCCESS;
 }
 
@@ -377,6 +206,9 @@ static pmix_buffer_t* pack_get(char *nspace, int rank,
     return msg;
 }
 
+/* this callback is coming from the usock recv, and thus
+ * is occurring inside of our progress thread - hence, no
+ * need to thread shift */
 static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata)
 {
@@ -410,7 +242,7 @@ static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     /* look up the nspace object for this proc */
     nptr = NULL;
     PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (0 == strcmp(cb->nspace, ns->nspace)) {
+        if (0 == strncmp(cb->nspace, ns->nspace, PMIX_MAX_NSLEN)) {
             nptr = ns;
             break;
         }
@@ -500,23 +332,169 @@ static void getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     }
 }
 
-static void getnb_shortcut(int fd, short flags, void *cbdata)
+static void _getnbfn(int fd, short flags, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
-    pmix_value_t val;
+    pmix_cb_t *cbret;
+    pmix_buffer_t *msg;
+    pmix_value_t *val;
     pmix_status_t rc;
-    int32_t m;
+    char *nm;
+    pmix_nspace_t *ns, *nptr;
+    size_t n;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "getnb_shortcut called with %s cbfunc",
-                        (NULL == cb->value_cbfunc) ? "NULL" : "NON-NULL");
+                        "pmix: getnbfn value for proc %s:%d key %s",
+                        cb->nspace, cb->rank,
+                        (NULL == cb->key) ? "NULL" : cb->key);
 
-    PMIX_VALUE_CONSTRUCT(&val);
-    if (NULL != cb->value_cbfunc) {
-        m=1;
-        rc = pmix_bfrop.unpack(&cb->data, &val, &m, PMIX_VALUE);
-        cb->value_cbfunc(rc, &val, cb->cbdata);
+    /* if the nspace is empty, then the caller is referencing
+     * our own nspace */
+    if (0 == strlen(cb->nspace)) {
+        nm = pmix_globals.myid.nspace;
+    } else {
+        nm = (char*)cb->nspace;
     }
-    PMIX_VALUE_DESTRUCT(&val);
-    PMIX_RELEASE(cb);
+
+    /* find the nspace object */
+    nptr = NULL;
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_nspace_t) {
+        if (0 == strcmp(nm, ns->nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        /* we are asking for info about a new nspace - give us
+         * a chance to learn about it from the server. If the
+         * server has never heard of it, the server will return
+         * an error */
+         nptr = PMIX_NEW(pmix_nspace_t);
+         (void)strncpy(nptr->nspace, nm, PMIX_MAX_NSLEN);
+         pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+         /* there is no point in looking for data in this nspace
+          * object, so let's just go generate the request */
+         goto request;
+    }
+
+    /* the requested data could be in the job-data table, so let's
+     * just check there first.  */
+    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, PMIX_RANK_WILDCARD, cb->key, &val))) {
+        /* found it - we are in an event, so we can
+         * just execute the callback */
+        cb->value_cbfunc(rc, val, cb->cbdata);
+        /* cleanup */
+        if (NULL != val) {
+            PMIX_VALUE_RELEASE(val);
+        }
+        PMIX_RELEASE(cb);
+        return;
+    }
+    if (PMIX_RANK_WILDCARD == cb->rank) {
+        /* can't be anywhere else */
+        cb->value_cbfunc(PMIX_ERR_NOT_FOUND, NULL, cb->cbdata);
+        PMIX_RELEASE(cb);
+        return;
+    }
+
+    /* it could still be in the job-data table, only stored under its own
+     * rank and not WILDCARD - e.g., this is true of data returned about
+     * ourselves during startup */
+    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, cb->rank, cb->key, &val))) {
+        /* found it - we are in an event, so we can
+         * just execute the callback */
+        cb->value_cbfunc(rc, val, cb->cbdata);
+        /* cleanup */
+        if (NULL != val) {
+            PMIX_VALUE_RELEASE(val);
+        }
+        PMIX_RELEASE(cb);
+        return;
+    }
+
+    /* not finding it is not an error - it could be in the
+     * modex hash table, so check it */
+    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->modex, cb->rank, cb->key, &val))) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix: value retrieved from dstore");
+        /* found it - we are in an event, so we can
+         * just execute the callback */
+        cb->value_cbfunc(rc, val, cb->cbdata);
+        /* cleanup */
+        if (NULL != val) {
+            PMIX_VALUE_RELEASE(val);
+        }
+        PMIX_RELEASE(cb);
+        return;
+    } else if (PMIX_ERR_NOT_FOUND == rc) {
+        /* we have the modex data from this proc, but didn't find the key
+         * the user requested. At this time, there is no way for the
+         * key to eventually be found, so all we can do is return
+         * the error */
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "Error requesting key=%s for rank = %d, namespace = %s",
+                            cb->key, cb->rank, nm);
+        cb->value_cbfunc(rc, NULL, cb->cbdata);
+        /* protect the data */
+        cb->procs = NULL;
+        cb->key = NULL;
+        cb->info = NULL;
+        PMIX_RELEASE(cb);
+        return;
+    }
+
+  request:
+    /* if we got here, then we don't have the data for this proc. If we
+     * are a server, or we are a client and not connected, then there is
+     * nothing more we can do */
+    if (pmix_globals.server || (!pmix_globals.server && !pmix_globals.connected)) {
+        cb->value_cbfunc(PMIX_ERR_NOT_FOUND, NULL, cb->cbdata);
+        PMIX_RELEASE(cb);
+        return;
+    }
+
+    /* we also have to check the user's directives to see if they do not want
+     * us to attempt to retrieve it from the server */
+    for (n=0; n < cb->ninfo; n++) {
+        if (0 == strcmp(cb->info[n].key, PMIX_OPTIONAL) &&
+            cb->info[n].value.data.flag) {
+            /* they don't want us to try and retrieve it */
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "PMIx_Get key=%s for rank = %d, namespace = %s was not found - request was optional",
+                                cb->key, cb->rank, nm);
+            cb->value_cbfunc(PMIX_ERR_NOT_FOUND, NULL, cb->cbdata);
+            PMIX_RELEASE(cb);
+            return;
+        }
+    }
+
+    /* see if we already have a request in place with the server for data from
+     * this nspace:rank. If we do, then no need to ask again as the
+     * request will return _all_ data from that proc */
+    PMIX_LIST_FOREACH(cbret, &pmix_client_globals.pending_requests, pmix_cb_t) {
+        if (0 == strncmp(cbret->nspace, nm, PMIX_MAX_NSLEN) &&
+            cbret->rank == cb->rank) {
+            /* we do have a pending request, but we still need to track this
+             * outstanding request so we can satisfy it once the data is returned */
+            pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
+            return;
+        }
+    }
+
+    /* we don't have a pending request, so let's create one - don't worry
+     * about packing the key as we return everything from that proc */
+    msg = pack_get(nm, cb->rank, cb->info, cb->ninfo, PMIX_GETNB_CMD);
+    if (NULL == msg) {
+        cb->value_cbfunc(PMIX_ERROR, NULL, cb->cbdata);
+        PMIX_RELEASE(cb);
+        return;
+    }
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
+
+    /* push the message into our event base to send to the server */
+    PMIX_ACTIVATE_SEND_RECV(&pmix_client_globals.myserver, msg, getnb_cbfunc, cb);
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -693,12 +693,10 @@ static void _execute_collective(int sd, short args, void *cbdata)
                     pmix_bfrop.pack(&rankbuf, &info->rank, 1, PMIX_INT);
                     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
                     PMIX_LOAD_BUFFER(&xfer, val->data.bo.bytes, val->data.bo.size);
+                    PMIX_VALUE_RELEASE(val);
                     pmix_buffer_t *pxfer = &xfer;
                     pmix_bfrop.pack(&rankbuf, &pxfer, 1, PMIX_BUFFER);
-                    xfer.base_ptr = NULL;
-                    xfer.bytes_used = 0;
                     PMIX_DESTRUCT(&xfer);
-                    PMIX_VALUE_RELEASE(val);
                     /* now pack this proc's contribution into the bucket */
                     pmix_buffer_t *pdatabuf = &rankbuf;
                     pmix_bfrop.pack(&databuf, &pdatabuf, 1, PMIX_BUFFER);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -550,12 +550,10 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
                     pmix_bfrop.pack(&rankbuf, &rkinfo->rank, 1, PMIX_INT);
                     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
                     PMIX_LOAD_BUFFER(&xfer, val->data.bo.bytes, val->data.bo.size);
+                    PMIX_VALUE_RELEASE(val);
                     pmix_buffer_t *pxfer = &xfer;
                     pmix_bfrop.pack(&rankbuf, &pxfer, 1, PMIX_BUFFER);
-                    xfer.base_ptr = NULL;
-                    xfer.bytes_used = 0;
                     PMIX_DESTRUCT(&xfer);
-                    PMIX_VALUE_RELEASE(val);
                     /* now pack this proc's contribution into the bucket */
                     pmix_buffer_t *pdatabuf = &rankbuf;
                     pmix_bfrop.pack(&databuf, &pdatabuf, 1, PMIX_BUFFER);

--- a/src/usock/usock.c
+++ b/src/usock/usock.c
@@ -273,13 +273,14 @@ static void cbcon(pmix_cb_t *p)
     p->rank = -1;
     p->key = NULL;
     p->value = NULL;
+    p->procs = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->nvals = 0;
 }
 static void cbdes(pmix_cb_t *p)
 {
     PMIX_DESTRUCT(&p->data);
-    if (NULL != p->key) {
-        free(p->key);
-    }
 }
 PMIX_CLASS_INSTANCE(pmix_cb_t,
                    pmix_list_item_t,

--- a/src/usock/usock.h
+++ b/src/usock/usock.h
@@ -169,6 +169,8 @@ typedef struct {
     pmix_event_t ev;
     volatile bool active;
     int status;
+    pmix_status_t pstatus;
+    pmix_scope_t scope;
     pmix_buffer_t data;
     pmix_usock_cbfunc_t cbfunc;
     pmix_op_cbfunc_t op_cbfunc;
@@ -180,9 +182,21 @@ typedef struct {
     int rank;
     char *key;
     pmix_value_t *value;
+    pmix_proc_t *procs;
+    pmix_info_t *info;
+    size_t ninfo;
     size_t nvals;
 } pmix_cb_t;
 PMIX_CLASS_DECLARATION(pmix_cb_t);
+
+/* an internal macro for shifting incoming requests
+ * to the internal event thread */
+#define PMIX_THREAD_SHIFT(c, f)                             \
+    do {                                                    \
+       event_assign(&((c)->ev), pmix_globals.evbase, -1,    \
+                          EV_WRITE, (f), (c));              \
+        event_active(&((c)->ev), EV_WRITE, 1);              \
+    } while(0);
 
 typedef struct {
     pmix_object_t super;


### PR DESCRIPTION
Fix double-free error in pmix_server_commit.
Fix PMIX_LOAD_BUFFER to be safe. Fix its usages accordingly.

(cherry picked from commit pmix/master@f18bdb423fb5ef2055d191df83d15b720f8e7b69)

Fix several issues identified by Paul Hargrove:

* PMIx_Init(NULL) is supported
* Incomplete PMIx_constants man page had some lingering cruft
* Missing prototype for pmix_value_load

Fixes #11
Fixes #12
Fixes #13

(cherry picked from commit pmix/master@53a4849f868c4111d728e8c3682d81fa498130ca)

Fix race condition in PMIx_Get/PMIx_Get_nb

(cherry picked from commit pmix/master@eb419b3e0788988bc046c1b1527edfb18ed120bd)

Fix a few places where thread safety wasn't provided

Address identified issues, plus a few other places where we strdup'd things that could be avoided.

(cherry picked from commit pmix/master@9b0eb6a6333affb0d99444fd5e3038de56352f38)

We need to thread-shift calls into PMIx_Get_nb because it accesses global data

(cherry picked from commit pmix/master@9aa6a13527eb297ec7144def21945168dbfcc4ab)

Address the latest round of comments by changing the pmix_cb_t destructor to avoid releasing its assigned data. Use the nspace/rank fields of pmix_cb_t for the get operation to simplify things

(cherry picked from commit pmix/master@339aa269b168074506029009e31806ecd3ca14c3)