### PR TITLE
Remove early development assumptions that force debug.

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -668,12 +668,6 @@ else
     AC_MSG_RESULT([no])
     WANT_DEBUG=0
 fi
-#################### Early development override ####################
-if test "$WANT_DEBUG" = "0" && test -z "$enable_debug" && test "$PMIX_DEVEL" = "1"; then
-    WANT_DEBUG=1
-    echo "--> developer override: enable debugging code by default"
-fi
-#################### Early development override ####################
 if test "$WANT_DEBUG" = "0"; then
     CFLAGS="-DNDEBUG $CFLAGS"
     CXXFLAGS="-DNDEBUG $CXXFLAGS"


### PR DESCRIPTION
This brakes server-side with client-side communications when:
a. Server-side was compiled separately with "--disable-debug" which
should be the same as default.
b. Client-side is compiled inside OMPI, OMPI assumes that if no
"--enable-debug" was passed to OMPI ./configure than all it needs
is not to specify "--enable-debug" in integrated pmix ./configure.
However in fact it will be implicitly enabled by the code that this
commit removes.