### PR TITLE
Fix some inconsistencies in pmix_status_t vs int declarations

### DIFF
--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +28,7 @@
 #include "src/util/output.h"
 #include "src/buffer_ops/internal.h"
 
-int pmix_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
+ pmix_status_t pmix_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
 {
     pmix_bfrop_type_info_t *info;
 
@@ -51,7 +52,7 @@ int pmix_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
     return info->odti_copy_fn(dest, src, type);
 }
 
-int pmix_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
+pmix_status_t pmix_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
 {
     size_t to_copy = 0;
     char *ptr;
@@ -80,7 +81,7 @@ int pmix_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
 /*
  * STANDARD COPY FUNCTION - WORKS FOR EVERYTHING NON-STRUCTURED
  */
-int pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
+ pmix_status_t pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
 {
     size_t datasize;
     uint8_t *val = NULL;
@@ -156,7 +157,7 @@ int pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
 /*
  * STRING
  */
-int pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
+ pmix_status_t pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 {
     if (NULL == src) {  /* got zero-length string/NULL pointer - store NULL */
         *dest = NULL;
@@ -320,7 +321,7 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
 }
 
 /* PMIX_VALUE */
-int pmix_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
+pmix_status_t pmix_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
                           pmix_data_type_t type)
 {
     pmix_value_t *p;
@@ -338,7 +339,7 @@ int pmix_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
     return pmix_value_xfer(p, src);
 }
 
-int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
+pmix_status_t pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
                          pmix_data_type_t type)
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
@@ -346,7 +347,7 @@ int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 
-int pmix_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
+pmix_status_t pmix_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
                         pmix_data_type_t type)
 {
     *dest = PMIX_NEW(pmix_buffer_t);
@@ -354,7 +355,7 @@ int pmix_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
+pmix_status_t pmix_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
                         pmix_data_type_t type)
 {
     size_t j;
@@ -374,7 +375,7 @@ int pmix_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
+pmix_status_t pmix_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
                          pmix_data_type_t type)
 {
     pmix_kval_t *p;
@@ -392,7 +393,7 @@ int pmix_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
     return pmix_value_xfer(p->value, src->value);
 }
 
-int pmix_bfrop_copy_array(pmix_info_array_t **dest,
+pmix_status_t pmix_bfrop_copy_array(pmix_info_array_t **dest,
                           pmix_info_array_t *src,
                           pmix_data_type_t type)
 {
@@ -407,7 +408,7 @@ int pmix_bfrop_copy_array(pmix_info_array_t **dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
+pmix_status_t pmix_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
                          pmix_data_type_t type)
 {
     *dest = (pmix_proc_t*)malloc(sizeof(pmix_proc_t));
@@ -420,7 +421,7 @@ int pmix_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
 }
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_copy_topo(hwloc_topology_t *dest,
+pmix_status_t pmix_bfrop_copy_topo(hwloc_topology_t *dest,
                          hwloc_topology_t src,
                          pmix_data_type_t type)
 {
@@ -429,7 +430,7 @@ int pmix_bfrop_copy_topo(hwloc_topology_t *dest,
 }
 #endif
 
-int pmix_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
+pmix_status_t pmix_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                           pmix_data_type_t type)
 {
     *dest = (pmix_modex_data_t*)malloc(sizeof(pmix_modex_data_t));
@@ -449,7 +450,7 @@ int pmix_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
+pmix_status_t pmix_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
                             pmix_data_type_t type)
 {
     *dest = (pmix_persistence_t*)malloc(sizeof(pmix_persistence_t));
@@ -460,7 +461,7 @@ int pmix_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
+pmix_status_t pmix_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
                        pmix_data_type_t type)
 {
     *dest = (pmix_byte_object_t*)malloc(sizeof(pmix_byte_object_t));
@@ -473,7 +474,7 @@ int pmix_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
+pmix_status_t pmix_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
                           pmix_data_type_t type)
 {
     *dest = (pmix_pdata_t*)malloc(sizeof(pmix_pdata_t));

--- a/src/buffer_ops/internal.h
+++ b/src/buffer_ops/internal.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -194,8 +195,8 @@ PMIX_DECLSPEC PMIX_CLASS_DECLARATION(pmix_bfrop_type_info_t);
  * globals needed within bfrop
  */
 extern bool pmix_bfrop_initialized;
-extern int pmix_bfrop_initial_size;
-extern int pmix_bfrop_threshold_size;
+extern size_t pmix_bfrop_initial_size;
+extern size_t pmix_bfrop_threshold_size;
 extern pmix_pointer_array_t pmix_bfrop_types;
 extern pmix_data_type_t pmix_bfrop_num_reg_types;
 
@@ -218,18 +219,18 @@ extern pmix_data_type_t pmix_bfrop_num_reg_types;
  * Implementations of API functions
  */
 
-int pmix_bfrop_pack(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack(pmix_buffer_t *buffer, const void *src,
                   int32_t num_vals,
                   pmix_data_type_t type);
-int pmix_bfrop_unpack(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix_bfrop_unpack(pmix_buffer_t *buffer, void *dest,
                     int32_t *max_num_vals,
                     pmix_data_type_t type);
 
-int pmix_bfrop_copy(void **dest, void *src, pmix_data_type_t type);
+ pmix_status_t pmix_bfrop_copy(void **dest, void *src, pmix_data_type_t type);
 
-int pmix_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type);
+ pmix_status_t pmix_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type);
 
-int pmix_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
+ pmix_status_t pmix_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
 
 /*
  * Specialized functions
@@ -244,214 +245,214 @@ PMIX_DECLSPEC    pmix_status_t pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, v
  * Internal pack functions
  */
 
-int pmix_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type);
 
-int pmix_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
 
-int pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type);
 
-int pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
                             int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
 #endif
-int pmix_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
                             int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
                        int32_t num_vals, pmix_data_type_t type);
-int pmix_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type);
 
 /*
  * Internal unpack functions
  */
-int pmix_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
 pmix_status_t pmix_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
 pmix_status_t pmix_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type);
 
 pmix_status_t pmix_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
                                     int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
 pmix_status_t pmix_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
 
-int pmix_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
                              int32_t *num_vals, pmix_data_type_t type);
 
-int pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
                               int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
 #endif
 pmix_status_t pmix_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
                               int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
                          int32_t *num_vals, pmix_data_type_t type);
-int pmix_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type);
 
 /*
  * Internal copy functions
  */
 
-int pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type);
 
-int pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_copy_topo(hwloc_topology_t *dest,
+pmix_status_t pmix_bfrop_copy_topo(hwloc_topology_t *dest,
                          hwloc_topology_t src,
                          pmix_data_type_t type);
 #endif
-int pmix_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
+pmix_status_t pmix_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
                           pmix_data_type_t type);
-int pmix_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_array_t *src,
+pmix_status_t pmix_bfrop_copy_array(pmix_info_array_t **dest, pmix_info_array_t *src,
                           pmix_data_type_t type);
-int pmix_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
+pmix_status_t pmix_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
                           pmix_data_type_t type);
-int pmix_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
+pmix_status_t pmix_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
                         pmix_data_type_t type);
-int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
+pmix_status_t pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
                          pmix_data_type_t type);
-int pmix_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
+pmix_status_t pmix_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
                         pmix_data_type_t type);
-int pmix_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
+pmix_status_t pmix_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
                          pmix_data_type_t type);
-int pmix_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
+pmix_status_t pmix_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
                           pmix_data_type_t type);
-int pmix_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
+pmix_status_t pmix_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
                             pmix_data_type_t type);
-int pmix_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
+pmix_status_t pmix_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
                        pmix_data_type_t type);
-int pmix_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
+pmix_status_t pmix_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
                           pmix_data_type_t type);
 
 /*
  * Internal print functions
  */
-int pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type);
-int pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type);
-int pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type);
 
-int pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type);
-int pmix_bfrop_print_int8(char **output, char *prefix, int8_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_int16(char **output, char *prefix, int16_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_int64(char **output, char *prefix, int64_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_int8(char **output, char *prefix, int8_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_int16(char **output, char *prefix, int16_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_int64(char **output, char *prefix, int64_t *src, pmix_data_type_t type);
 
-int pmix_bfrop_print_uint(char **output, char *prefix, int *src, pmix_data_type_t type);
-int pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_uint32(char **output, char *prefix, uint32_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_uint64(char **output, char *prefix, uint64_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_uint32(char **output, char *prefix, uint32_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_uint64(char **output, char *prefix, uint64_t *src, pmix_data_type_t type);
 
-int pmix_bfrop_print_float(char **output, char *prefix, float *src, pmix_data_type_t type);
-int pmix_bfrop_print_double(char **output, char *prefix, double *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_float(char **output, char *prefix, float *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_double(char **output, char *prefix, double *src, pmix_data_type_t type);
 
-int pmix_bfrop_print_timeval(char **output, char *prefix, struct timeval *src, pmix_data_type_t type);
-int pmix_bfrop_print_time(char **output, char *prefix, time_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_timeval(char **output, char *prefix, struct timeval *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_time(char **output, char *prefix, time_t *src, pmix_data_type_t type);
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_print_topo(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_topo(char **output, char *prefix,
                           hwloc_topology_t src, pmix_data_type_t type);
 #endif
-int pmix_bfrop_print_value(char **output, char *prefix, pmix_value_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_array(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_value(char **output, char *prefix, pmix_value_t *src, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_print_array(char **output, char *prefix,
                            pmix_info_array_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_proc(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_proc(char **output, char *prefix,
                            pmix_proc_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_app(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_app(char **output, char *prefix,
                          pmix_app_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_info(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_info(char **output, char *prefix,
                           pmix_info_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_buf(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_buf(char **output, char *prefix,
                           pmix_buffer_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_kval(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_kval(char **output, char *prefix,
                           pmix_kval_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_modex(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_modex(char **output, char *prefix,
                            pmix_modex_data_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_persist(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_persist(char **output, char *prefix,
                              pmix_persistence_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_bo(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_bo(char **output, char *prefix,
                         pmix_byte_object_t *src, pmix_data_type_t type);
-int pmix_bfrop_print_pdata(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_pdata(char **output, char *prefix,
                            pmix_pdata_t *src, pmix_data_type_t type);
 
 /*
@@ -464,7 +465,7 @@ bool pmix_bfrop_too_small(pmix_buffer_t *buffer, size_t bytes_reqd);
 
 pmix_bfrop_type_info_t* pmix_bfrop_find_type(pmix_data_type_t type);
 
-int pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
+pmix_status_t pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
 
 pmix_status_t pmix_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type);
 

--- a/src/buffer_ops/internal_functions.c
+++ b/src/buffer_ops/internal_functions.c
@@ -10,6 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,7 @@ char* pmix_bfrop_buffer_extend(pmix_buffer_t *buffer, size_t bytes_to_add)
     }
 
     required = buffer->bytes_used + bytes_to_add;
-    if(required >= (size_t)pmix_bfrop_threshold_size) {
+    if (required >= pmix_bfrop_threshold_size) {
         to_alloc = ((required + pmix_bfrop_threshold_size - 1)
                     / pmix_bfrop_threshold_size) * pmix_bfrop_threshold_size;
     } else {
@@ -108,13 +109,13 @@ bool pmix_bfrop_too_small(pmix_buffer_t *buffer, size_t bytes_reqd)
     return false;
 }
 
-int pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
 {
     /* Lookup the pack function for the actual pmix_data_type type and call it */
     return pmix_bfrop_pack_datatype(buffer, &type, 1, PMIX_INT);
 }
 
-int pmix_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
+pmix_status_t pmix_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
 {
     int32_t n=1;
     return pmix_bfrop_unpack_datatype(buffer, type, &n, PMIX_INT);

--- a/src/buffer_ops/open_close.c
+++ b/src/buffer_ops/open_close.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,8 +39,8 @@
  * globals
  */
 bool pmix_bfrop_initialized = false;
-int pmix_bfrop_initial_size = 0;
-int pmix_bfrop_threshold_size = 0;
+size_t pmix_bfrop_initial_size = 0;
+size_t pmix_bfrop_threshold_size = 0;
 pmix_pointer_array_t pmix_bfrop_types = {{0}};
 pmix_data_type_t pmix_bfrop_num_reg_types = PMIX_UNDEF;
 static pmix_bfrop_buffer_type_t pmix_default_buf_type = PMIX_BFROP_BUFFER_NON_DESC;

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -15,6 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,11 +36,11 @@
 #include "src/util/output.h"
 #include "src/buffer_ops/internal.h"
 
-int pmix_bfrop_pack(pmix_buffer_t *buffer,
+ pmix_status_t pmix_bfrop_pack(pmix_buffer_t *buffer,
                     const void *src, int32_t num_vals,
                     pmix_data_type_t type)
 {
-    int rc;
+    pmix_status_t rc;
 
     /* check for error */
     if (NULL == buffer) {
@@ -60,11 +61,11 @@ int pmix_bfrop_pack(pmix_buffer_t *buffer,
     return pmix_bfrop_pack_buffer(buffer, src, num_vals, type);
 }
 
-int pmix_bfrop_pack_buffer(pmix_buffer_t *buffer,
+pmix_status_t pmix_bfrop_pack_buffer(pmix_buffer_t *buffer,
                            const void *src, int32_t num_vals,
                            pmix_data_type_t type)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_bfrop_type_info_t *info;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_pack_buffer( %p, %p, %lu, %d )\n",
@@ -92,7 +93,7 @@ int pmix_bfrop_pack_buffer(pmix_buffer_t *buffer,
 /*
  * BOOL
  */
-int pmix_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     uint8_t *dst;
@@ -124,10 +125,10 @@ int pmix_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
 /*
  * INT
  */
-int pmix_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them */
@@ -142,10 +143,10 @@ int pmix_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
 /*
  * SIZE_T
  */
-int pmix_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
@@ -159,10 +160,10 @@ int pmix_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
 /*
  * PID_T
  */
-int pmix_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
@@ -180,7 +181,7 @@ int pmix_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
 /*
  * BYTE, CHAR, INT8
  */
-int pmix_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     char *dst;
@@ -204,7 +205,7 @@ int pmix_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
 /*
  * INT16
  */
-int pmix_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -231,7 +232,7 @@ int pmix_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
 /*
  * INT32
  */
-int pmix_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -255,7 +256,7 @@ int pmix_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     return pmix_bfrop_pack_int32(buffer, src, num_vals, type);
@@ -264,7 +265,7 @@ int pmix_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
 /*
  * INT64
  */
-int pmix_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -293,7 +294,7 @@ int pmix_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
 /*
  * STRING
  */
-int pmix_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -322,10 +323,10 @@ int pmix_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
 }
 
 /* FLOAT */
-int pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
-    int ret = PMIX_SUCCESS;
+    pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
     float *ssrc = (float*)src;
     char *convert;
@@ -343,10 +344,10 @@ int pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
 }
 
 /* DOUBLE */
-int pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
                            int32_t num_vals, pmix_data_type_t type)
 {
-    int ret = PMIX_SUCCESS;
+    pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
     double *ssrc = (double*)src;
     char *convert;
@@ -364,11 +365,11 @@ int pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIMEVAL */
-int pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
                             int32_t num_vals, pmix_data_type_t type)
 {
     int64_t tmp[2];
-    int ret = PMIX_SUCCESS;
+    pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
     struct timeval *ssrc = (struct timeval *)src;
 
@@ -384,10 +385,10 @@ int pmix_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIME */
-int pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
-    int ret = PMIX_SUCCESS;
+    pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
     time_t *ssrc = (time_t *)src;
     uint64_t ui64;
@@ -407,10 +408,10 @@ int pmix_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
 
 
 /* PACK FUNCTIONS FOR GENERIC PMIX TYPES */
-static int pack_val(pmix_buffer_t *buffer,
+static pmix_status_t pack_val(pmix_buffer_t *buffer,
                     pmix_value_t *p)
 {
-    int ret;
+    pmix_status_t ret;
 
     switch (p->type) {
     case PMIX_BOOL:
@@ -523,12 +524,12 @@ static int pack_val(pmix_buffer_t *buffer,
 /*
  * PMIX_VALUE
  */
-int pmix_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     ptr = (pmix_value_t *) src;
 
@@ -547,12 +548,12 @@ int pmix_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
 }
 
 
-int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_t *info;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
     char *foo;
 
     info = (pmix_info_t *) src;
@@ -575,12 +576,12 @@ int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *pdata;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
     char *foo;
 
     pdata = (pmix_pdata_t *) src;
@@ -607,12 +608,12 @@ int pmix_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t **ptr;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     ptr = (pmix_buffer_t **) src;
 
@@ -631,12 +632,12 @@ int pmix_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *proc;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     proc = (pmix_proc_t *) src;
 
@@ -652,12 +653,12 @@ int pmix_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
                         int32_t num_vals, pmix_data_type_t type)
 {
     pmix_app_t *app;
     int32_t i, j, nvals;
-    int ret;
+    pmix_status_t ret;
 
     app = (pmix_app_t *) src;
 
@@ -702,12 +703,12 @@ int pmix_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
 }
 
 
-int pmix_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     ptr = (pmix_kval_t *) src;
 
@@ -725,12 +726,12 @@ int pmix_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     ptr = (pmix_info_array_t *) src;
 
@@ -751,12 +752,13 @@ int pmix_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
 }
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
                          int32_t num_vals, pmix_data_type_t type)
 {
     /* NOTE: hwloc defines topology_t as a pointer to a struct! */
     hwloc_topology_t t, *tarray  = (hwloc_topology_t*)src;
-    int rc, i;
+    pmix_status_t rc;
+    int i;
     char *xmlbuffer=NULL;
     int len;
     struct hwloc_topology_support *support;
@@ -808,12 +810,12 @@ int pmix_bfrop_pack_topo(pmix_buffer_t *buffer, const void *src,
 }
 #endif
 
-int pmix_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i;
-    int ret;
+    pmix_status_t ret;
 
     ptr = (pmix_modex_data_t *) src;
 
@@ -830,16 +832,16 @@ int pmix_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
                             int32_t num_vals, pmix_data_type_t type)
 {
     return pmix_bfrop_pack_int(buffer, src, num_vals, PMIX_INT);
 }
 
-int pmix_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
                        int32_t num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
     int i;
     pmix_byte_object_t *bo;
 

--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,7 +32,7 @@
 
 #include "src/buffer_ops/internal.h"
 
-int pmix_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type)
 {
     pmix_bfrop_type_info_t *info;
 
@@ -53,7 +53,7 @@ int pmix_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t ty
 /*
  * STANDARD PRINT FUNCTIONS FOR SYSTEM TYPES
  */
-int pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -79,7 +79,7 @@ int pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -104,7 +104,7 @@ int pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_t
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -129,7 +129,7 @@ int pmix_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_ty
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -154,7 +154,7 @@ int pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_ty
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -178,7 +178,7 @@ int pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -203,7 +203,7 @@ int pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_uint(char **output, char *prefix, int *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -228,7 +228,7 @@ int pmix_bfrop_print_uint(char **output, char *prefix, int *src, pmix_data_type_
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -253,7 +253,7 @@ int pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -278,7 +278,7 @@ int pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_dat
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_uint32(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_uint32(char **output, char *prefix,
                             uint32_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -304,7 +304,7 @@ int pmix_bfrop_print_uint32(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_int8(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_int8(char **output, char *prefix,
                           int8_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -330,7 +330,7 @@ int pmix_bfrop_print_int8(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_int16(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_int16(char **output, char *prefix,
                            int16_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -356,7 +356,7 @@ int pmix_bfrop_print_int16(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -380,7 +380,7 @@ int pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_
 
     return PMIX_SUCCESS;
 }
-int pmix_bfrop_print_uint64(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_uint64(char **output, char *prefix,
                             uint64_t *src,
                             pmix_data_type_t type)
 {
@@ -407,7 +407,7 @@ int pmix_bfrop_print_uint64(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_int64(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_int64(char **output, char *prefix,
                            int64_t *src,
                            pmix_data_type_t type)
 {
@@ -434,7 +434,7 @@ int pmix_bfrop_print_int64(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_float(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_float(char **output, char *prefix,
                            float *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -460,7 +460,7 @@ int pmix_bfrop_print_float(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_double(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_double(char **output, char *prefix,
                             double *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -486,7 +486,7 @@ int pmix_bfrop_print_double(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_time(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_time(char **output, char *prefix,
                           time_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -516,7 +516,7 @@ int pmix_bfrop_print_time(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_timeval(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_timeval(char **output, char *prefix,
                              struct timeval *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -548,7 +548,7 @@ int pmix_bfrop_print_timeval(char **output, char *prefix,
 /*
  * PMIX_VALUE
  */
-int pmix_bfrop_print_value(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_value(char **output, char *prefix,
                            pmix_value_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -645,7 +645,7 @@ int pmix_bfrop_print_value(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_info(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_info(char **output, char *prefix,
                           pmix_info_t *src, pmix_data_type_t type)
 {
     char *tmp;
@@ -659,7 +659,7 @@ int pmix_bfrop_print_info(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_pdata(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_pdata(char **output, char *prefix,
                           pmix_pdata_t *src, pmix_data_type_t type)
 {
     char *tmp1, *tmp2;
@@ -677,19 +677,19 @@ int pmix_bfrop_print_pdata(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_buf(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_buf(char **output, char *prefix,
                          pmix_buffer_t *src, pmix_data_type_t type)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_app(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_app(char **output, char *prefix,
                          pmix_app_t *src, pmix_data_type_t type)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_proc(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_proc(char **output, char *prefix,
                            pmix_proc_t *src, pmix_data_type_t type)
 {
     char *prefx;
@@ -702,13 +702,13 @@ int pmix_bfrop_print_proc(char **output, char *prefix,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_kval(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_kval(char **output, char *prefix,
                           pmix_kval_t *src, pmix_data_type_t type)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_array(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_array(char **output, char *prefix,
                            pmix_info_array_t *src, pmix_data_type_t type)
 {
     size_t j;
@@ -804,7 +804,7 @@ static void print_hwloc_obj(char **output, char *prefix,
     *output = tmp2;
 }
 
-int pmix_bfrop_print_topo(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_topo(char **output, char *prefix,
                           hwloc_topology_t src, pmix_data_type_t type)
 {
     hwloc_obj_t obj;
@@ -820,13 +820,13 @@ int pmix_bfrop_print_topo(char **output, char *prefix,
 
 #endif
 
-int pmix_bfrop_print_modex(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_modex(char **output, char *prefix,
                            pmix_modex_data_t *src, pmix_data_type_t type)
 {
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_persist(char **output, char *prefix, pmix_persistence_t *src, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_print_persist(char **output, char *prefix, pmix_persistence_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
@@ -851,7 +851,7 @@ int pmix_bfrop_print_persist(char **output, char *prefix, pmix_persistence_t *sr
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_print_bo(char **output, char *prefix,
+pmix_status_t pmix_bfrop_print_bo(char **output, char *prefix,
                         pmix_byte_object_t *src, pmix_data_type_t type)
 {
     char *prefx;

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -15,6 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,10 +33,10 @@
 #include "src/buffer_ops/types.h"
 #include "src/buffer_ops/internal.h"
 
-int pmix_bfrop_unpack(pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
+pmix_status_t pmix_bfrop_unpack(pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
                       pmix_data_type_t type)
 {
-    int rc, ret;
+    pmix_status_t rc, ret;
     int32_t local_num, n=1;
     pmix_data_type_t local_type;
 
@@ -147,7 +148,7 @@ pmix_status_t pmix_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t
 /*
  * BOOL
  */
-int pmix_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -207,10 +208,10 @@ pmix_status_t pmix_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
 /*
  * SIZE_T
  */
-int pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
     pmix_data_type_t remote_type;
 
     if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &remote_type))) {
@@ -233,10 +234,10 @@ int pmix_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
 /*
  * PID_T
  */
-int pmix_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type)
 {
-    int ret;
+    pmix_status_t ret;
     pmix_data_type_t remote_type;
 
     if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &remote_type))) {
@@ -280,7 +281,7 @@ pmix_status_t pmix_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -326,13 +327,13 @@ pmix_status_t pmix_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     return pmix_bfrop_unpack_int32(buffer, dest, num_vals, type);
 }
 
-int pmix_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -382,12 +383,12 @@ pmix_status_t pmix_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     float *desttmp = (float*) dest, tmp;
-    int ret;
+    pmix_status_t ret;
     char *convert;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_unpack_float * %d\n", (int)*num_vals);
@@ -412,12 +413,12 @@ int pmix_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
                              int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     double *desttmp = (double*) dest, tmp;
-    int ret;
+    pmix_status_t ret;
     char *convert;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_unpack_double * %d\n", (int)*num_vals);
@@ -442,13 +443,13 @@ int pmix_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
                               int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     int64_t tmp[2];
     struct timeval *desttmp = (struct timeval *) dest, tt;
-    int ret;
+    pmix_status_t ret;
 
     pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrop_unpack_timeval * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
@@ -469,12 +470,12 @@ int pmix_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     time_t *desttmp = (time_t *) dest, tmp;
-    int ret;
+    pmix_status_t ret;
     uint64_t ui64;
 
     /* time_t is a system-dependent size, so cast it
@@ -507,7 +508,7 @@ int pmix_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
  */
 static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
 {
-    int m;
+    int32_t m;
     pmix_status_t ret;
 
     m = 1;
@@ -644,12 +645,12 @@ pmix_status_t pmix_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
     char *tmp;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
@@ -689,12 +690,12 @@ int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
     char *tmp;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
@@ -738,12 +739,12 @@ int pmix_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t **ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
     size_t nbytes;
 
     ptr = (pmix_buffer_t **) dest;
@@ -777,12 +778,12 @@ int pmix_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
     char *tmp;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
@@ -815,12 +816,12 @@ int pmix_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_app_t *ptr;
     int32_t i, k, n, m;
-    int ret;
+    pmix_status_t ret;
     int32_t nval;
     char *tmp;
 
@@ -894,7 +895,7 @@ int pmix_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
@@ -927,12 +928,12 @@ int pmix_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-int pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
                         "pmix_bfrop_unpack: %d info arrays", *num_vals);
@@ -961,13 +962,14 @@ int pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
 }
 
 #if PMIX_HAVE_HWLOC
-int pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
                            int32_t *num_vals,
                            pmix_data_type_t type)
 {
     /* NOTE: hwloc defines topology_t as a pointer to a struct! */
     hwloc_topology_t t, *tarray  = (hwloc_topology_t*)dest;
-    int rc=PMIX_SUCCESS, i, cnt, j;
+    pmix_status_t rc=PMIX_SUCCESS;
+    int32_t cnt, i, j;
     char *xmlbuffer;
     struct hwloc_topology_support *support;
 
@@ -1042,12 +1044,12 @@ int pmix_bfrop_unpack_topo(pmix_buffer_t *buffer, void *dest,
 }
 #endif
 
-int pmix_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
                         "pmix_bfrop_unpack: %d modex", *num_vals);
@@ -1074,18 +1076,18 @@ int pmix_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
 }
 
 
-int pmix_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
                             int32_t *num_vals, pmix_data_type_t type)
 {
     return pmix_bfrop_unpack_int(buffer, dest, num_vals, PMIX_INT);
 }
 
-int pmix_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
                          int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_byte_object_t *ptr;
     int32_t i, n, m;
-    int ret;
+    pmix_status_t ret;
 
     pmix_output_verbose(20, pmix_globals.debug_output,
                         "pmix_bfrop_unpack: %d byte_object", *num_vals);

--- a/src/class/pmix_hash_table.c
+++ b/src/class/pmix_hash_table.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -296,7 +297,7 @@ pmix_status_t pmix_hash_table_set_value_uint64(pmix_hash_table_t* ht,
 }
 
 
-int pmix_hash_table_remove_value_uint64(pmix_hash_table_t* ht, uint64_t key)
+pmix_status_t pmix_hash_table_remove_value_uint64(pmix_hash_table_t* ht, uint64_t key)
 {
     pmix_list_t* list = ht->ht_table + (key & ht->ht_mask);
     pmix_uint64_hash_node_t *node;
@@ -362,7 +363,7 @@ static inline uint32_t pmix_hash_value(size_t mask, const void *key,
     return (uint32_t) (crc & mask);
 }
 
-int pmix_hash_table_get_value_ptr(pmix_hash_table_t* ht, const void* key,
+pmix_status_t pmix_hash_table_get_value_ptr(pmix_hash_table_t* ht, const void* key,
 				  size_t key_size, void **ptr)
 {
     pmix_list_t* list = ht->ht_table + pmix_hash_value(ht->ht_mask, key,
@@ -389,7 +390,7 @@ int pmix_hash_table_get_value_ptr(pmix_hash_table_t* ht, const void* key,
 }
 
 
-int pmix_hash_table_set_value_ptr(pmix_hash_table_t* ht, const void* key,
+pmix_status_t pmix_hash_table_set_value_ptr(pmix_hash_table_t* ht, const void* key,
                                   size_t key_size, void* value)
 {
     pmix_list_t* list = ht->ht_table + pmix_hash_value(ht->ht_mask, key,
@@ -430,7 +431,7 @@ int pmix_hash_table_set_value_ptr(pmix_hash_table_t* ht, const void* key,
 }
 
 
-int pmix_hash_table_remove_value_ptr(pmix_hash_table_t* ht,
+pmix_status_t pmix_hash_table_remove_value_ptr(pmix_hash_table_t* ht,
                                      const void* key, size_t key_size)
 {
     pmix_list_t* list = ht->ht_table + pmix_hash_value(ht->ht_mask,
@@ -462,7 +463,7 @@ int pmix_hash_table_remove_value_ptr(pmix_hash_table_t* ht,
 }
 
 
-int
+pmix_status_t
 pmix_hash_table_get_first_key_uint32(pmix_hash_table_t *ht, uint32_t *key,
                                      void **value, void **node)
 {
@@ -489,7 +490,7 @@ pmix_hash_table_get_first_key_uint32(pmix_hash_table_t *ht, uint32_t *key,
 }
 
 
-int
+pmix_status_t
 pmix_hash_table_get_next_key_uint32(pmix_hash_table_t *ht, uint32_t *key,
                                     void **value, void *in_node,
                                     void **out_node)
@@ -534,7 +535,7 @@ pmix_hash_table_get_next_key_uint32(pmix_hash_table_t *ht, uint32_t *key,
 }
 
 
-int
+pmix_status_t
 pmix_hash_table_get_first_key_uint64(pmix_hash_table_t *ht, uint64_t *key,
                                      void **value, void **node)
 {
@@ -561,7 +562,7 @@ pmix_hash_table_get_first_key_uint64(pmix_hash_table_t *ht, uint64_t *key,
 }
 
 
-int
+pmix_status_t
 pmix_hash_table_get_next_key_uint64(pmix_hash_table_t *ht, uint64_t *key,
                                     void **value, void *in_node,
                                     void **out_node)

--- a/src/class/pmix_hash_table.h
+++ b/src/class/pmix_hash_table.h
@@ -14,7 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,12 +73,12 @@ typedef struct pmix_hash_table_t pmix_hash_table_t;
  *
  */
 
-PMIX_DECLSPEC int pmix_hash_table_init(pmix_hash_table_t* ht, size_t table_size);
+PMIX_DECLSPEC pmix_status_t pmix_hash_table_init(pmix_hash_table_t* ht, size_t table_size);
 
 /**
  * Alternative form
  */
-PMIX_DECLSPEC int pmix_hash_table_init2(pmix_hash_table_t* ht, size_t estimated_max_size,
+PMIX_DECLSPEC pmix_status_t pmix_hash_table_init2(pmix_hash_table_t* ht, size_t estimated_max_size,
                                         int density_numer, int density_denom,
                                         int growth_numer, int growth_denom);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -7,6 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -235,10 +236,11 @@ PMIX_EXPORT const char* PMIx_Get_version(void)
     return pmix_version_string;
 }
 
-PMIX_EXPORT int PMIx_Init(pmix_proc_t *proc)
+PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc)
 {
     char **uri, *evar;
-    int rc, debug_level;
+    pmix_status_t rc;
+    int debug_level;
     struct sockaddr_un address;
     pmix_nspace_t *nsptr;
     pmix_cb_t cb;
@@ -481,7 +483,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(void)
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT int PMIx_Abort(int flag, const char msg[],
+PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
                pmix_proc_t procs[], size_t nprocs)
 {
     pmix_buffer_t *bfr;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,12 +59,12 @@
 /* callback for wait completion */
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
-static void op_cbfunc(int status, void *cbdata);
+static void op_cbfunc(pmix_status_t status, void *cbdata);
 
-PMIX_EXPORT int PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
+PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
                              const pmix_info_t info[], size_t ninfo)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -172,10 +172,10 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT int PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
+PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
 
     if (pmix_globals.init_cntr <= 0) {
@@ -327,7 +327,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     }
 }
 
-static void op_cbfunc(int status, void *cbdata)
+static void op_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
 

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -7,6 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,20 +57,20 @@
 
 #include "pmix_client_ops.h"
 
-static int unpack_return(pmix_buffer_t *data);
-static int pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd,
+static pmix_status_t unpack_return(pmix_buffer_t *data);
+static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd,
                       const pmix_proc_t *procs, size_t nprocs,
                       const pmix_info_t *info, size_t ninfo);
 static void wait_cbfunc(struct pmix_peer_t *pr,
                         pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
-static void op_cbfunc(int status, void *cbdata);
+static void op_cbfunc(pmix_status_t status, void *cbdata);
 
-PMIX_EXPORT int PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
+PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
                            const pmix_info_t info[], size_t ninfo)
 {
     pmix_cb_t *cb;
-    int rc;
+    pmix_status_t rc;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: executing fence");
@@ -107,13 +108,13 @@ PMIX_EXPORT int PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     return rc;
 }
 
-PMIX_EXPORT int PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
+PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
                               const pmix_info_t info[], size_t ninfo,
                               pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FENCENB_CMD;
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
     pmix_proc_t rg, *rgs;
     size_t nrg;
@@ -168,7 +169,7 @@ PMIX_EXPORT int PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
 static pmix_status_t unpack_return(pmix_buffer_t *data)
 {
     pmix_status_t rc;
-    int ret;
+    pmix_status_t ret;
     int32_t cnt;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -245,7 +246,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     PMIX_RELEASE(cb);
 }
 
-static void op_cbfunc(int status, void *cbdata)
+static void op_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
 

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -7,6 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,14 +66,14 @@ static void _getnbfn(int sd, short args, void *cbdata);
 static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                          pmix_buffer_t *buf, void *cbdata);
 
-static void _value_cbfunc(int status, pmix_value_t *kv, void *cbdata);
+static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata);
 
-PMIX_EXPORT int PMIx_Get(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
                          const pmix_info_t info[], size_t ninfo,
                          pmix_value_t **val)
 {
     pmix_cb_t *cb;
-    int rc;
+    pmix_status_t rc;
 
     if (pmix_globals.init_cntr <= 0) {
         return PMIX_ERR_INIT;
@@ -169,7 +170,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
     return PMIX_SUCCESS;
 }
 
-static void _value_cbfunc(int status, pmix_value_t *kv, void *cbdata)
+static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     pmix_status_t rc;

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,10 +58,10 @@
 
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
-static void op_cbfunc(int status, void *cbdata);
+static void op_cbfunc(pmix_status_t status, void *cbdata);
 static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                                pmix_buffer_t *buf, void *cbdata);
-static void lookup_cbfunc(int status, pmix_pdata_t pdata[], size_t ndata,
+static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t ndata,
                           void *cbdata);
 
 PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[],
@@ -169,10 +169,10 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT int PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata,
+PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata,
                             const pmix_info_t info[], size_t ninfo)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
     char **keys = NULL;
     size_t i;
@@ -296,10 +296,10 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys,
     return PMIX_SUCCESS;
 }
 
-PMIX_EXPORT int PMIx_Unpublish(char **keys,
+PMIX_EXPORT pmix_status_t PMIx_Unpublish(char **keys,
                                const pmix_info_t info[], size_t ninfo)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -421,7 +421,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     PMIX_RELEASE(cb);
 }
 
-static void op_cbfunc(int status, void *cbdata)
+static void op_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
 
@@ -495,7 +495,7 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     PMIX_RELEASE(cb);
 }
 
-static void lookup_cbfunc(int status, pmix_pdata_t pdata[], size_t ndata,
+static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t ndata,
                           void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,13 +58,13 @@
 
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
-static void spawn_cbfunc(int status, char nspace[], void *cbdata);
+static void spawn_cbfunc(pmix_status_t status, char nspace[], void *cbdata);
 
-PMIX_EXPORT int PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
+PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                            const pmix_app_t apps[], size_t napps,
                            char nspace[])
 {
-    int rc;
+    pmix_status_t rc;
     pmix_cb_t *cb;
 
     pmix_output_verbose(2, pmix_globals.debug_output,

--- a/src/sec/pmix_native.c
+++ b/src/sec/pmix_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,7 +28,7 @@
 static int native_init(void);
 static void native_finalize(void);
 static char* create_cred(void);
-static int validate_cred(pmix_peer_t *peer, char *cred);
+static pmix_status_t validate_cred(pmix_peer_t *peer, char *cred);
 
 pmix_sec_base_module_t pmix_native_module = {
     "native",
@@ -70,7 +70,7 @@ static char* create_cred(void)
     return cred;
 }
 
-static int validate_cred(pmix_peer_t *peer, char *cred)
+static pmix_status_t validate_cred(pmix_peer_t *peer, char *cred)
 {
     uid_t uid;
     gid_t gid;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -7,6 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1697,7 +1698,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
  ****    IMMEDIATELY. THUS ANYTHING THAT ACCESSES A GLOBAL ENTITY        ****
  ****    MUST BE PUSHED INTO AN EVENT FOR PROTECTION                     ****/
 
-static void op_cbfunc(int status, void *cbdata)
+static void op_cbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
     pmix_buffer_t *reply;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -5,7 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  */
 
@@ -147,7 +147,7 @@ typedef struct {
     } while (0)
 
 
-int pmix_start_listening(struct sockaddr_un *address);
+pmix_status_t pmix_start_listening(struct sockaddr_un *address);
 void pmix_stop_listening(void);
 
 bool pmix_server_trk_update(pmix_server_trkr_t *trk);

--- a/src/usock/usock.c
+++ b/src/usock/usock.c
@@ -6,6 +6,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,7 +78,7 @@ void pmix_usock_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_usock_globals.posted_recvs);
 }
 
-int pmix_usock_set_nonblocking(int sd)
+pmix_status_t  pmix_usock_set_nonblocking(int sd)
 {
     int flags;
      /* setup the socket as non-blocking */
@@ -95,7 +96,7 @@ int pmix_usock_set_nonblocking(int sd)
     return PMIX_SUCCESS;
 }
 
-int pmix_usock_set_blocking(int sd)
+pmix_status_t  pmix_usock_set_blocking(int sd)
 {
     int flags;
      /* setup the socket as non-blocking */

--- a/src/usock/usock.h
+++ b/src/usock/usock.h
@@ -20,7 +20,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -185,8 +185,8 @@ extern pmix_usock_globals_t pmix_usock_globals;
 /* usock common functions */
 void pmix_usock_init(pmix_usock_cbfunc_t cbfunc);
 void pmix_usock_finalize(void);
-int pmix_usock_set_nonblocking(int sd);
-int pmix_usock_set_blocking(int sd);
+pmix_status_t pmix_usock_set_nonblocking(int sd);
+pmix_status_t  pmix_usock_set_blocking(int sd);
 pmix_status_t pmix_usock_send_blocking(int sd, char *ptr, size_t size);
 pmix_status_t pmix_usock_recv_blocking(int sd, char *data, size_t size);
 void pmix_usock_send_recv(int sd, short args, void *cbdata);

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -11,7 +11,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- *
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,7 +65,7 @@ static pmix_kval_t* lookup_keyval(pmix_list_t *data,
 static pmix_proc_data_t* lookup_proc(pmix_hash_table_t *jtable,
                                      uint64_t id, bool create);
 
-int pmix_hash_store(pmix_hash_table_t *table,
+pmix_status_t pmix_hash_store(pmix_hash_table_t *table,
                     int rank, pmix_kval_t *kin)
 {
     pmix_proc_data_t *proc_data;
@@ -229,7 +229,7 @@ pmix_status_t pmix_hash_fetch_by_key(pmix_hash_table_t *table, const char *key,
     return PMIX_SUCCESS;
 }
 
-int pmix_hash_remove_data(pmix_hash_table_t *table,
+pmix_status_t pmix_hash_remove_data(pmix_hash_table_t *table,
                           int rank, const char *key)
 {
     pmix_status_t rc = PMIX_SUCCESS;

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -92,7 +93,7 @@ char **pmix_environ_merge(char **minor, char **major)
  * Portable version of setenv(), allowing editing of any environ-like
  * array
  */
-int pmix_setenv(const char *name, const char *value, bool overwrite,
+ pmix_status_t pmix_setenv(const char *name, const char *value, bool overwrite,
                 char ***env)
 {
     int i;
@@ -175,7 +176,7 @@ int pmix_setenv(const char *name, const char *value, bool overwrite,
  * Portable version of unsetenv(), allowing editing of any
  * environ-like array
  */
-int pmix_unsetenv(const char *name, char ***env)
+ pmix_status_t pmix_unsetenv(const char *name, char ***env)
 {
     int i;
     char *compare;

--- a/src/util/pmix_environ.h
+++ b/src/util/pmix_environ.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2015      Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -112,7 +113,7 @@ PMIX_DECLSPEC char **pmix_environ_merge(char **minor, char **major) __pmix_attri
  *   pmix_setenv("foo", "bar", true, &my_env);
  * \endcode
  */
-PMIX_DECLSPEC int pmix_setenv(const char *name, const char *value,
+PMIX_DECLSPEC pmix_status_t pmix_setenv(const char *name, const char *value,
                               bool overwrite, char ***env) __pmix_attribute_nonnull__(1);
 
 /**

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -4,6 +4,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -79,12 +80,12 @@ pmix_list_t *pmix_test_published_list = NULL;
 
 static int finalized_count = 0;
 
-int connected(const pmix_proc_t *proc, void *server_object)
+pmix_status_t connected(const pmix_proc_t *proc, void *server_object)
 {
     return PMIX_SUCCESS;
 }
 
-int finalized(const pmix_proc_t *proc, void *server_object,
+pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
               pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     if( CLI_TERM <= cli_info[proc->rank].state ){
@@ -105,7 +106,7 @@ int finalized(const pmix_proc_t *proc, void *server_object,
     return PMIX_SUCCESS;
 }
 
-int abort_fn(const pmix_proc_t *proc, void *server_object,
+pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object,
              int status, const char msg[],
              pmix_proc_t procs[], size_t nprocs,
              pmix_op_cbfunc_t cbfunc, void *cbdata)
@@ -119,7 +120,7 @@ int abort_fn(const pmix_proc_t *proc, void *server_object,
     return PMIX_SUCCESS;
 }
 
-int fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
                const pmix_info_t info[], size_t ninfo,
                char *data, size_t ndata,
                pmix_modex_cbfunc_t cbfunc, void *cbdata)
@@ -139,7 +140,7 @@ int fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     return PMIX_SUCCESS;
 }
 
-int dmodex_fn(const pmix_proc_t *proc,
+pmix_status_t dmodex_fn(const pmix_proc_t *proc,
               const pmix_info_t info[], size_t ninfo,
               pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
@@ -156,7 +157,7 @@ int dmodex_fn(const pmix_proc_t *proc,
     return PMIX_SUCCESS;
 }
 
-int publish_fn(const pmix_proc_t *proc,
+pmix_status_t publish_fn(const pmix_proc_t *proc,
                const pmix_info_t info[], size_t ninfo,
                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -189,7 +190,7 @@ int publish_fn(const pmix_proc_t *proc,
     return PMIX_SUCCESS;
 }
 
-int lookup_fn(const pmix_proc_t *proc, char **keys,
+pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
               const pmix_info_t info[], size_t ninfo,
               pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
@@ -221,7 +222,7 @@ int lookup_fn(const pmix_proc_t *proc, char **keys,
     return PMIX_SUCCESS;
 }
 
-int unpublish_fn(const pmix_proc_t *proc, char **keys,
+pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
                  const pmix_info_t info[], size_t ninfo,
                  pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -268,7 +269,7 @@ static void release_cb(pmix_status_t status, void *cbdata)
     free(cb);
 }
 
-int spawn_fn(const pmix_proc_t *proc,
+pmix_status_t spawn_fn(const pmix_proc_t *proc,
              const pmix_info_t job_info[], size_t ninfo,
              const pmix_app_t apps[], size_t napps,
              pmix_spawn_cbfunc_t cbfunc, void *cbdata)
@@ -281,7 +282,7 @@ int spawn_fn(const pmix_proc_t *proc,
     return PMIX_SUCCESS;
 }
 
-int connect_fn(const pmix_proc_t procs[], size_t nprocs,
+pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                const pmix_info_t info[], size_t ninfo,
                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -292,7 +293,7 @@ int connect_fn(const pmix_proc_t procs[], size_t nprocs,
    return PMIX_SUCCESS;
 }
 
-int disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                   const pmix_info_t info[], size_t ninfo,
                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -302,7 +303,7 @@ int disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
     return PMIX_SUCCESS;
 }
 
-int regevents_fn (const pmix_info_t info[], size_t ninfo,
+pmix_status_t regevents_fn (const pmix_info_t info[], size_t ninfo,
                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     TEST_VERBOSE ((" pmix host server regevents_fn called "));
@@ -312,7 +313,7 @@ int regevents_fn (const pmix_info_t info[], size_t ninfo,
     return PMIX_SUCCESS;
 }
 
-int deregevents_fn (const pmix_info_t info[], size_t ninfo,
+pmix_status_t deregevents_fn (const pmix_info_t info[], size_t ninfo,
                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     TEST_VERBOSE ((" pmix host server deregevents_fn called "));

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2015 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -377,7 +378,7 @@ static pmix_status_t connected(const pmix_proc_t *proc, void *server_object)
 {
     return PMIX_SUCCESS;
 }
-static int finalized(const pmix_proc_t *proc, void *server_object,
+static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_output(0, "SERVER: FINALIZED %s:%d",
@@ -401,9 +402,9 @@ static void abcbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(x);
 }
 
-static int abort_fn(const pmix_proc_t *proc,
+static pmix_status_t abort_fn(const pmix_proc_t *proc,
                     void *server_object,
-                    pmix_status_t status, const char msg[],
+                    int status, const char msg[],
                     pmix_proc_t procs[], size_t nprocs,
                     pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -441,7 +442,7 @@ static int abort_fn(const pmix_proc_t *proc,
 }
 
 
-static int fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+static pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
                       const pmix_info_t info[], size_t ninfo,
                       char *data, size_t ndata,
                       pmix_modex_cbfunc_t cbfunc, void *cbdata)
@@ -455,7 +456,7 @@ static int fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 }
 
 
-static int dmodex_fn(const pmix_proc_t *proc,
+static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
                      const pmix_info_t info[], size_t ninfo,
                      pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
@@ -470,7 +471,7 @@ static int dmodex_fn(const pmix_proc_t *proc,
 }
 
 
-static int publish_fn(const pmix_proc_t *proc,
+static pmix_status_t publish_fn(const pmix_proc_t *proc,
                       const pmix_info_t info[], size_t ninfo,
                       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -494,7 +495,7 @@ static int publish_fn(const pmix_proc_t *proc,
 }
 
 
-static int lookup_fn(const pmix_proc_t *proc, char **keys,
+static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
                      const pmix_info_t info[], size_t ninfo,
                      pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
@@ -543,7 +544,7 @@ static int lookup_fn(const pmix_proc_t *proc, char **keys,
 }
 
 
-static int unpublish_fn(const pmix_proc_t *proc, char **keys,
+static pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
                         const pmix_info_t info[], size_t ninfo,
                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -576,7 +577,7 @@ static void spcbfunc(pmix_status_t status, void *cbdata)
     }
 }
 
-static int spawn_fn(const pmix_proc_t *proc,
+static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                     const pmix_info_t job_info[], size_t ninfo,
                     const pmix_app_t apps[], size_t napps,
                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
@@ -602,7 +603,7 @@ static int spawn_fn(const pmix_proc_t *proc,
 }
 
 
-static int connect_fn(const pmix_proc_t procs[], size_t nprocs,
+static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                       const pmix_info_t info[], size_t ninfo,
                       pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -619,7 +620,7 @@ static int connect_fn(const pmix_proc_t procs[], size_t nprocs,
 }
 
 
-static int disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                          const pmix_info_t info[], size_t ninfo,
                          pmix_op_cbfunc_t cbfunc, void *cbdata)
 {


### PR DESCRIPTION
 * These were found when building on power7 with XL compiler
 * See the following PR from Open MPI for more details:
   - https://github.com/open-mpi/ompi-release/pull/1129