### PR TITLE
Cleanup a couple of missed commits

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -639,7 +639,8 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[])
     PMIX_THREADSHIFT(cd, _deregister_nspace);
 }
 
- void pmix_server_execute_collective(int sd, short args, void *cbdata) {
+void pmix_server_execute_collective(int sd, short args, void *cbdata)
+{
     pmix_trkr_caddy_t *tcd = (pmix_trkr_caddy_t*)cbdata;
     pmix_server_trkr_t *trk = tcd->trk;
     char *data = NULL;

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -92,7 +92,7 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
     }
     /* set the mode as required */
     if (0 != chmod(address->sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH)) {
-        pmix_output(0, "CANNOT CHMOD %s\n", address->sun_path);
+        pmix_output(0, "CANNOT CHMOD %s", address->sun_path);
         return PMIX_ERROR;
     }
 

--- a/test/pmi_client.c
+++ b/test/pmi_client.c
@@ -271,12 +271,12 @@ static int test_item4(void)
     log_info("PMI_Get_clique_size=%d\n", val);
     log_assert((0 < val) && (val <= size), "");
 
-    ranks = alloca(val);
+    ranks = alloca(val*sizeof(int));
     if (!ranks) {
         return PMI_FAIL;
     }
 
-    memset(ranks, (-1), val);
+    memset(ranks, (-1), val*sizeof(int));
     if (PMI_SUCCESS != (rc = PMI_Get_clique_ranks(ranks, val))) {
         log_fatal("PMI_Get_clique_ranks failed: %d\n", rc);
         return rc;


### PR DESCRIPTION
 Transfer some updates for 1.1.4 from OMPI to PMIx repo. Includes cleanup and adjustment of collectives when a local client unexpectedly terminates

(cherry picked from commit pmix/master@c2c4144)

 Fix a mistaken call in this test - alloca takes an argument of #bytes to be allocated

(cherry picked from commit pmix/master@bde4da1)
