### PR TITLE
Update authentication methods per PMIx master

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -456,7 +456,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                          #endif
                      ])
 
-    #
+    AC_CHECK_MEMBERS([struct ucred.uid, struct ucred.cr_uid, struct sockpeercred.uid],
+                     [], [],
+                     [#include <sys/types.h>
+                      #include <sys/socket.h> ])
+
     # Check for ptrdiff type.  Yes, there are platforms where
     # sizeof(void*) != sizeof(long) (64 bit Windows, apparently).
     #
@@ -491,7 +495,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep getpeereid])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/config/pmix_check_munge.m4
+++ b/config/pmix_check_munge.m4
@@ -1,6 +1,6 @@
 # -*- shell-script -*-
 #
-# Copyright (c) 2015      Intel, Inc. All rights reserved
+# Copyright (c) 2015-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -24,9 +24,9 @@ AC_DEFUN([PMIX_MUNGE_CONFIG],[
                                 [Search for munge libraries in DIR ])])
 
     pmix_munge_support=0
-    if test "$with_munge" != "no"; then
+    if test ! -z "$with_munge" && test "$with_munge" != "no"; then
         AC_MSG_CHECKING([for munge in])
-        if test ! -z "$with_munge" && test "$with_munge" != "yes"; then
+        if test "$with_munge" != "yes"; then
             if test -d $with_munge/include/munge; then
                 pmix_munge_dir=$with_munge/include/munge
             else
@@ -76,8 +76,8 @@ AC_DEFUN([PMIX_MUNGE_CONFIG],[
         AC_MSG_RESULT([yes])
     fi
 
-    AC_DEFINE_UNQUOTED([PMIX_HAVE_MUNGE], [$pmix_munge_support],
-                       [Whether we have munge support or not])
+    AC_DEFINE_UNQUOTED([PMIX_WANT_MUNGE], [$pmix_munge_support],
+                       [Whether we want munge support or not])
 
     PMIX_VAR_SCOPE_POP
 ])dnl

--- a/config/pmix_check_sasl.m4
+++ b/config/pmix_check_sasl.m4
@@ -27,9 +27,9 @@ AC_DEFUN([PMIX_SASL_CONFIG],[
                                 [Search for sasl libraries in DIR ])])
 
     pmix_sasl_support=0
-    if test "$with_sasl" != "no"; then
+    if test ! -z "$with_sasl" && test "$with_sasl" != "no"; then
         AC_MSG_CHECKING([for sasl in])
-        if test ! -z "$with_sasl" && test "$with_sasl" != "yes"; then
+        if test "$with_sasl" != "yes"; then
             pmix_sasl_dir=$with_sasl/include/sasl
             if test -d $with_sasl/lib; then
                 pmix_sasl_libdir=$with_sasl/lib

--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -93,6 +93,9 @@ BEGIN_C_DECLS
 #define PMIX_USERID                "pmix.euid"              // (uint32_t) effective user id
 #define PMIX_GRPID                 "pmix.egid"              // (uint32_t) effective group id
 
+/* attributes for the rendezvous socket  */
+#define PMIX_SOCKET_MODE           "pmix.sockmode"          // (uint32_t) POSIX mode_t (9 bits valid)
+
 /* general proc-level attributes */
 #define PMIX_CPUSET                "pmix.cpuset"            // (char*) hwloc bitmap applied to proc upon launch
 #define PMIX_CREDENTIAL            "pmix.cred"              // (char*) security credential assigned to proc

--- a/src/sec/pmix_munge.c
+++ b/src/sec/pmix_munge.c
@@ -118,7 +118,7 @@ static int validate_cred(pmix_peer_t *peer, char *cred)
     munge_err_t rc;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: munge validate_cred %s", cred);
+                        "sec: munge validate_cred %s", cred ? cred : "NULL");
 
     /* parse the inbound string */
     if (EMUNGE_SUCCESS != (rc = munge_decode(cred, NULL, NULL, NULL, &uid, &gid))) {

--- a/src/sec/pmix_native.c
+++ b/src/sec/pmix_native.c
@@ -12,6 +12,7 @@
 
 #include <pmix/pmix_common.h>
 
+#include "src/include/pmix_socket_errno.h"
 #include "src/include/pmix_globals.h"
 #include "src/util/argv.h"
 #include "src/util/output.h"
@@ -27,14 +28,13 @@
 
 static int native_init(void);
 static void native_finalize(void);
-static char* create_cred(void);
 static pmix_status_t validate_cred(pmix_peer_t *peer, char *cred);
 
 pmix_sec_base_module_t pmix_native_module = {
     "native",
     native_init,
     native_finalize,
-    create_cred,
+    NULL,
     NULL,
     validate_cred,
     NULL
@@ -53,56 +53,71 @@ static void native_finalize(void)
                         "sec: native finalize");
 }
 
-static char* create_cred(void)
-{
-    char *cred;
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: native create_cred");
-
-    /* print them and return the string */
-    (void)asprintf(&cred, "%lu:%lu", (unsigned long)pmix_globals.uid,
-                   (unsigned long)pmix_globals.gid);
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: using credential %s", cred);
-
-    return cred;
-}
-
 static pmix_status_t validate_cred(pmix_peer_t *peer, char *cred)
 {
-    uid_t uid;
+#if defined(SO_PEERCRED)
+#ifdef HAVE_STRUCT_SOCKPEERCRED_UID
+#define HAVE_STRUCT_UCRED_UID
+    struct sockpeercred ucred;
+#else
+    struct ucred ucred;
+#endif
+    socklen_t crlen = sizeof (ucred);
+#endif
+    uid_t euid;
     gid_t gid;
-    char **vals;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: native validate_cred %s", cred);
+                        "sec: native validate_cred %s", cred ? cred : "NULL");
 
-    /* parse the inbound string */
-    vals = pmix_argv_split(cred, ':');
-    if (2 != pmix_argv_count(vals)) {
-        pmix_argv_free(vals);
+#if defined(SO_PEERCRED) && (defined(HAVE_STRUCT_UCRED_UID) || defined(HAVE_STRUCT_UCRED_CR_UID))
+    /* Ignore received 'cred' and validate ucred for socket instead. */
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "sec:native checking getsockopt for peer credentials");
+    if (getsockopt (peer->sd, SOL_SOCKET, SO_PEERCRED, &ucred, &crlen) < 0) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "sec: getsockopt SO_PEERCRED failed: %s",
+                            strerror (pmix_socket_errno));
         return PMIX_ERR_INVALID_CRED;
     }
+#if defined(HAVE_STRUCT_UCRED_UID)
+    euid = ucred.uid;
+    gid = ucred.gid;
+#else
+    euid = ucred.cr_uid;
+    gid = ucred.cr_gid;
+#endif
+
+#elif defined(HAVE_GETPEEREID)
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "sec:native checking getpeereid for peer credentials");
+    if (0 != getpeereid(peer->sd, &euid, &gid)) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "sec: getsockopt getpeereid failed: %s",
+                            strerror (pmix_socket_errno));
+        return PMIX_ERR_INVALID_CRED;
+    }
+#else
+    return PMIX_ERR_NOT_SUPPORTED;
+#endif
 
     /* check uid */
-    uid = strtoul(vals[0], NULL, 10);
-    if (uid != peer->info->uid) {
-        pmix_argv_free(vals);
+    if (euid != peer->info->uid) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "sec: socket cred contains invalid uid %u", euid);
         return PMIX_ERR_INVALID_CRED;
     }
 
-    /* check guid */
-    gid = strtoul(vals[1], NULL, 10);
+    /* check gid */
     if (gid != peer->info->gid) {
-        pmix_argv_free(vals);
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "sec: socket cred contains invalid gid %u", gid);
         return PMIX_ERR_INVALID_CRED;
     }
-    pmix_argv_free(vals);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: native credential valid");
+                        "sec: native credential %u:%u valid",
+                        euid, gid);
     return PMIX_SUCCESS;
 }
 

--- a/src/sec/pmix_sec.c
+++ b/src/sec/pmix_sec.c
@@ -45,7 +45,7 @@
 #include "pmix_sec.h"
 
 #include "src/sec/pmix_native.h"
-#if PMIX_HAVE_MUNGE
+#if PMIX_WANT_MUNGE
 #include "src/sec/pmix_munge.h"
 #endif
 #
@@ -61,12 +61,9 @@
 #define PMIX_SEC_NAVAIL  3
 
 static pmix_sec_base_module_t *all[] = {
-#if PMIX_HAVE_MUNGE
-    /* Start the array with the least heavy option, if available */
+#if PMIX_WANT_MUNGE
     &pmix_munge_module,
 #endif
-
-    /* Our native module should always be the lowest priority */
     &pmix_native_module,
 
     /* Always end the array with a NULL */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -245,6 +245,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_status_t rc;
     size_t n;
     pmix_kval_t kv;
+    uid_t sockuid = -1;
+    gid_t sockgid = -1;
+    mode_t sockmode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;
 
     ++pmix_globals.init_cntr;
     if (1 < pmix_globals.init_cntr) {
@@ -272,10 +275,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         for (n=0; n < ninfo; n++) {
             if (0 == strcmp(info[n].key, PMIX_USERID)) {
                 /* the userid is in the uint32_t storage */
-                chown(myaddress.sun_path, info[n].value.data.uint32, -1);
+                sockuid = info[n].value.data.uint32;
             } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
                /* the grpid is in the uint32_t storage */
-                chown(myaddress.sun_path, -1, info[n].value.data.uint32);
+                sockgid = info[n].value.data.uint32;
+            } else if (0 == strcmp(info[n].key, PMIX_SOCKET_MODE)) {
+                sockmode = info[n].value.data.uint32 & 0777;
             }
         }
     }
@@ -288,32 +293,29 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_list_append(&pmix_usock_globals.posted_recvs, &req->super);
 
     /* start listening */
-    if (PMIX_SUCCESS != pmix_start_listening(&myaddress)) {
+    if (PMIX_SUCCESS != pmix_start_listening(&myaddress, sockmode, sockuid, sockgid)) {
         PMIx_server_finalize();
         return PMIX_ERR_INIT;
     }
 
-    /* check the info keys for a directive about the uid/gid
-     * to be set for the rendezvous file, and any info we
+    /* check the info keys for info we
      * need to provide to every client */
     if (NULL != info) {
         PMIX_CONSTRUCT(&kv, pmix_kval_t);
         for (n=0; n < ninfo; n++) {
-            if (0 == strcmp(info[n].key, PMIX_USERID)) {
-                /* the userid is in the uint32_t storage */
-                chown(myaddress.sun_path, info[n].value.data.uint32, -1);
-            } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
-                /* the grpid is in the uint32_t storage */
-                chown(myaddress.sun_path, -1, info[n].value.data.uint32);
-            } else {
-                /* store and pass along to every client */
-                kv.key = info[n].key;
-                kv.value = &info[n].value;
-                if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&pmix_server_globals.gdata, &kv, 1, PMIX_KVAL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&kv);
-                    return rc;
-                }
+            if (0 == strcmp(info[n].key, PMIX_USERID))
+                continue;
+            if (0 == strcmp(info[n].key, PMIX_GRPID))
+                continue;
+            if (0 == strcmp(info[n].key, PMIX_SOCKET_MODE))
+                continue;
+            /* store and pass along to every client */
+            kv.key = info[n].key;
+            kv.value = &info[n].value;
+            if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&pmix_server_globals.gdata, &kv, 1, PMIX_KVAL))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&kv);
+                return rc;
             }
         }
         /* protect the incoming data */

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -71,7 +71,8 @@ static pthread_t engine;
 /*
  * start listening on our rendezvous file
  */
-pmix_status_t pmix_start_listening(struct sockaddr_un *address)
+pmix_status_t pmix_start_listening(struct sockaddr_un *address,
+                                   mode_t mode, uid_t sockuid, gid_t sockgid)
 {
     int flags;
     pmix_status_t rc;
@@ -90,27 +91,32 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
         printf("%s:%d bind() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
+    /* chown as required */
+    if (0 != chown(address->sun_path, sockuid, sockgid)) {
+        pmix_output(0, "CANNOT CHOWN socket %s: %s", address->sun_path, strerror (errno));
+        goto sockerror;
+    }
     /* set the mode as required */
-    if (0 != chmod(address->sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH)) {
-        pmix_output(0, "CANNOT CHMOD %s", address->sun_path);
-        return PMIX_ERROR;
+    if (0 != chmod(address->sun_path, mode)) {
+        pmix_output(0, "CANNOT CHMOD socket %s: %s", address->sun_path, strerror (errno));
+        goto sockerror;
     }
 
     /* setup listen backlog to maximum allowed by kernel */
     if (listen(pmix_server_globals.listen_socket, SOMAXCONN) < 0) {
         printf("%s:%d listen() failed\n", __FILE__, __LINE__);
-        return PMIX_ERROR;
+        goto sockerror;
     }
 
     /* set socket up to be non-blocking, otherwise accept could block */
     if ((flags = fcntl(pmix_server_globals.listen_socket, F_GETFL, 0)) < 0) {
         printf("%s:%d fcntl(F_GETFL) failed\n", __FILE__, __LINE__);
-        return PMIX_ERROR;
+        goto sockerror;
     }
     flags |= O_NONBLOCK;
     if (fcntl(pmix_server_globals.listen_socket, F_SETFL, flags) < 0) {
         printf("%s:%d fcntl(F_SETFL) failed\n", __FILE__, __LINE__);
-        return PMIX_ERROR;
+        goto sockerror;
     }
 
     /* setup my version for validating connections - we
@@ -156,6 +162,11 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
     }
 
     return PMIX_SUCCESS;
+
+sockerror:
+    (void)close(pmix_server_globals.listen_socket);
+    pmix_server_globals.listen_socket = -1;
+    return PMIX_ERROR;
 }
 
 void pmix_stop_listening(void)
@@ -295,6 +306,42 @@ static void listener_cb(int incoming_sd)
     event_active(&pending_connection->ev, EV_WRITE, 1);
 }
 
+/* Parse init-ack message:
+ *    NSPACE<0><rank>VERSION<0>[CRED<0>]
+ */
+static pmix_status_t parse_connect_ack (char *msg, int len,
+                                        char **nspace, int *rank,
+                                        char **version, char **cred)
+{
+    if ((int)strnlen (msg, len) < len) {
+        *nspace = msg;
+        msg += strlen(*nspace) + 1;
+        len -= strlen(*nspace) + 1;
+    } else
+        return PMIX_ERR_BAD_PARAM;
+
+    if ((int)sizeof(int) <= len) {
+        *rank = *(int *)msg;
+        msg += sizeof(int);
+        len -= sizeof(int);
+    } else
+        return PMIX_ERR_BAD_PARAM;
+
+    if ((int)strnlen (msg, len) < len) {
+        *version = msg;
+        msg += strlen(*version) + 1;
+        len -= strlen(*version) + 1;
+    } else
+        return PMIX_ERR_BAD_PARAM;
+
+    if ((int)strnlen (msg, len) < len)
+        *cred = msg;
+    else
+        *cred = NULL;
+
+    return PMIX_SUCCESS;
+}
+
 /*  Receive the peer's identification info from a newly
  *  connected socket and verify the expected response.
  */
@@ -308,7 +355,6 @@ static pmix_status_t pmix_server_authenticate(int sd, int *out_rank,
     pmix_nspace_t *nptr, *tmp;
     pmix_rank_info_t *info;
     pmix_peer_t *psave = NULL;
-    size_t csize;
     bool found;
     pmix_proc_t proc;
 
@@ -341,44 +387,22 @@ static pmix_status_t pmix_server_authenticate(int sd, int *out_rank,
         return PMIX_ERR_UNREACH;
     }
 
-    /* get the nspace */
-    nspace = msg;  // a NULL terminator is in the data
-
-    /* get the rank */
-    memcpy(&rank, msg+strlen(nspace)+1, sizeof(int));
+    if (PMIX_SUCCESS != (rc = parse_connect_ack (msg, hdr.nbytes, &nspace,
+                                                 &rank, &version, &cred))) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "error parsing connect-ack from client ON SOCKET %d", sd);
+        free(msg);
+        return rc;
+    }
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "connect-ack recvd from peer %s:%d",
-                        nspace, rank);
+                        "connect-ack recvd from peer %s:%d:%s",
+                        nspace, rank, version);
 
     /* do not check the version - we only retain it at this
      * time in case we need to check it at some future date.
      * For now, our intent is to retain backward compatibility
      * and so we will assume that all versions are compatible. */
-    csize = strlen(nspace)+1+sizeof(int);
-    version = (char*)(msg+csize);
-    csize += strlen(version) + 1;  // position ourselves before modifiying version
-#if 0
-    /* find the first '.' */
-    ptr = strchr(version, '.');
-    if (NULL != ptr) {
-        ++ptr;
-        /* stop it at the second '.', if present */
-        if (NULL != (ptr = strchr(ptr, '.'))) {
-            *ptr = '\0';
-        }
-    }
-    if (0 != strcmp(version, myversion)) {
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix:server client/server PMIx versions mismatch - server %s client %s",
-                            myversion, version);
-        free(msg);
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "connect-ack version from client matches ours");
-#endif
 
     /* see if we know this nspace */
     nptr = NULL;
@@ -429,21 +453,18 @@ static pmix_status_t pmix_server_authenticate(int sd, int *out_rank,
     }
 
     /* see if there is a credential */
-    if (csize < hdr.nbytes) {
-        cred = (char*)(msg + csize);
-        if (NULL != cred && NULL != pmix_sec.validate_cred) {
-            if (PMIX_SUCCESS != (rc = pmix_sec.validate_cred(psave, cred))) {
-                pmix_output_verbose(2, pmix_globals.debug_output,
-                                    "validation of client credential failed");
-                free(msg);
-                pmix_pointer_array_set_item(&pmix_server_globals.clients, psave->index, NULL);
-                PMIX_RELEASE(psave);
-                /* send an error reply to the client */
-                goto error;
-            }
+    if (NULL != pmix_sec.validate_cred) {
+        if (PMIX_SUCCESS != (rc = pmix_sec.validate_cred(psave, cred))) {
             pmix_output_verbose(2, pmix_globals.debug_output,
-                                "client credential validated");
+                                "validation of client credential failed");
+            free(msg);
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, psave->index, NULL);
+            PMIX_RELEASE(psave);
+            /* send an error reply to the client */
+            goto error;
         }
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "client credential validated");
     }
     free(msg);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -147,7 +147,8 @@ typedef struct {
     } while (0)
 
 
-pmix_status_t pmix_start_listening(struct sockaddr_un *address);
+pmix_status_t pmix_start_listening(struct sockaddr_un *address,
+		                   mode_t mode, uid_t sockuid, gid_t sockgid);
 void pmix_stop_listening(void);
 
 bool pmix_server_trk_update(pmix_server_trkr_t *trk);

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -207,8 +207,8 @@ pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
                                      int *index)
 {
     int i;
+    pmix_error_reg_info_t *errreg;
     pmix_status_t rc = PMIX_ERR_NOT_FOUND;
-    pmix_error_reg_info_t *errreg = NULL;
 
     for (i = 0; i < pmix_pointer_array_get_size(&pmix_globals.errregs) ; i++) {
         errreg = (pmix_error_reg_info_t*)pmix_pointer_array_get_item(&pmix_globals.errregs, i);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,6 +29,7 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h tes
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
+noinst_SCRIPTS = pmix_client_otheruser.sh
 noinst_PROGRAMS = pmi_client pmi2_client
 if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
@@ -64,3 +65,4 @@ pmix_regex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_regex_LDADD = \
 	$(top_builddir)/libpmix.la
 
+EXTRA_DIST = $(noinst_SCRIPTS)

--- a/test/pmix_client_otheruser.sh
+++ b/test/pmix_client_otheruser.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+OTHERUSER=dummy
+
+# To test sec:native we run client as a different user e.g.
+#
+#  ./pmix_test -e ./pmix_client_otheruser.sh
+#
+# Prerequisites:
+# - ensure directories leading up to source tree are o+x
+# - add dummy user and set OTHERUSER to its name
+# - give yourself passwordless sudo capability to that user
+#
+# The test should fail with message similar to
+#   PMIX ERROR: INVALID-CREDENTIAL in file 
+#       ../src/server/pmix_server_listener.c at line 524
+#
+
+sudo --user $OTHERUSER --preserve-env ./pmix_client $*

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -81,7 +81,12 @@ int main(int argc, char **argv)
     }
 
     /* setup the server library */
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+    pmix_info_t info[1];
+    (void)strncpy(info[0].key, PMIX_SOCKET_MODE, PMIX_MAX_KEYLEN);
+    info[0].value.type = PMIX_UINT32;
+    info[0].value.data.uint32 = 0666;
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
         TEST_ERROR(("Init failed with error %d", rc));
         FREE_TEST_PARAMS(params);
         return rc;


### PR DESCRIPTION
Merge pull request #92 from garlick/so_peercred security: validate connections with SO_PEERCRED + misc fixes
(cherry picked from commit pmix/master@c2c07587e572664c451a02442d2dc9ffcbc2813d)

Silence warnings

(cherry picked from commit pmix/master@5c290cf4f85c54151eb9ec9f8de0c5f936a00572)

Do not build munge or sasl support by default if either is present - only build if specifically requested.

(cherry picked from commit pmix/master@765fadb6c3a9a1b3a68d2d551c615db76e3c7dfd)

dd

Sadly, SO_PEERCRED is not a universal entity - there are a number of systems (e.g., Mac and other BSD variants) that do not support it. Update configury to check for its existence, and for the BSD alternative of getpeereid, and then use the appropriate version for the host platform

(cherry picked from commit pmix/master@18fb0dae9971629d187cacbe4dc119b151e425e9)

Sigh - get the #if's right for Linux

(cherry picked from commit pmix/master@fe67549d3e9f0246b80c804f5e9d7b3c037240f4)