### PR TITLE
Cleanup some of the compiler complaints about not checking return codes

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -61,7 +61,9 @@ int main(int argc, char **argv)
     fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* put a few values */
-    (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -70,7 +72,9 @@ int main(int argc, char **argv)
     }
     free(tmp);
 
-    (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
@@ -79,7 +83,9 @@ int main(int argc, char **argv)
     }
     free(tmp);
 
-    (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
@@ -108,7 +114,9 @@ int main(int argc, char **argv)
 
     /* check the returned data */
     for (n=0; n < nprocs; n++) {
-        (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank);
+        if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank)) {
+            exit(1);
+        }
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
             goto done;
@@ -128,7 +136,9 @@ int main(int argc, char **argv)
         fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s returned correct\n", myproc.nspace, myproc.rank, tmp);
         PMIX_VALUE_RELEASE(val);
         free(tmp);
-        (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
+        if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank)) {
+            exit(1);
+        }
         if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, tmp, NULL, 0, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, myproc.rank, tmp, rc);
             goto done;

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -117,7 +117,9 @@ int main(int argc, char **argv)
     fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* put a few values */
-    (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
@@ -126,7 +128,9 @@ int main(int argc, char **argv)
     }
     free(tmp);
 
-    (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_UINT64;
     value.data.uint64 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
@@ -135,7 +139,9 @@ int main(int argc, char **argv)
     }
     free(tmp);
 
-    (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
+    if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank)) {
+        exit(1);
+    }
     value.type = PMIX_STRING;
     value.data.string = "1234";
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
@@ -170,7 +176,9 @@ int main(int argc, char **argv)
     /* get the committed data - ask for someone who doesn't exist as well */
     num_gets = 0;
     for (n=0; n <= nprocs; n++) {
-        (void)asprintf(&tmp, "%s-%d-local", myproc.nspace, n);
+        if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, n)) {
+            exit(1);
+        }
         (void)strncpy(proc.nspace, tmp, PMIX_MAX_NSLEN);
         proc.rank = n;
         if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp,
@@ -179,7 +187,9 @@ int main(int argc, char **argv)
             goto done;
         }
         ++num_gets;
-        (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, n);
+        if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, n)) {
+            exit(1);
+        }
         (void)strncpy(proc.nspace, tmp, PMIX_MAX_NSLEN);
         if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp,
                                               NULL, 0, valcbfunc, tmp))) {

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -50,8 +50,12 @@ int main(int argc, char **argv)
     size_t npeers, ntmp=0;
     char *nodelist;
 
-    gethostname(hostname, sizeof(hostname));
-    getcwd(dir, 1024);
+    if (0 > gethostname(hostname, sizeof(hostname))) {
+        exit(1);
+    }
+    if (NULL == getcwd(dir, 1024)) {
+        exit(1);
+    }
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc))) {
@@ -81,11 +85,15 @@ int main(int argc, char **argv)
     /* rank=0 calls spawn */
     if (0 == myproc.rank) {
         PMIX_APP_CREATE(app, 1);
-        (void)asprintf(&app->cmd, "%s/client", dir);
+        if (0 > asprintf(&app->cmd, "%s/client", dir)) {
+            exit(1);
+        }
         app->maxprocs = 2;
         app->argc = 1;
         app->argv = (char**)malloc(2 * sizeof(char*));
-        (void)asprintf(&app->argv[0], "%s/client", dir);
+        if (0 > asprintf(&app->argv[0], "%s/client", dir)) {
+            exit(1);
+        }
         app->argv[1] = NULL;
         app->env = (char**)malloc(2 * sizeof(char*));
         app->env[0] = strdup("PMIX_ENV_VALUE=3");

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -332,7 +332,9 @@ pmix_status_t pmix_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
     char *convert;
 
     for (i = 0; i < num_vals; ++i) {
-        asprintf(&convert, "%f", ssrc[i]);
+        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+            return PMIX_ERR_NOMEM;
+        }
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;
@@ -353,7 +355,9 @@ pmix_status_t pmix_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
     char *convert;
 
     for (i = 0; i < num_vals; ++i) {
-        asprintf(&convert, "%f", ssrc[i]);
+        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+            return PMIX_ERR_NOMEM;
+        }
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;

--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -58,20 +58,30 @@ pmix_status_t pmix_bfrop_print_bool(char **output, char *prefix, bool *src, pmix
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    }
+    else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
-             (*src) ? "TRUE" : "FALSE");
+    if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
+             (*src) ? "TRUE" : "FALSE")) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -84,19 +94,28 @@ pmix_status_t pmix_bfrop_print_byte(char **output, char *prefix, uint8_t *src, p
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefix, *src);
+    if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefix, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -109,19 +128,28 @@ pmix_status_t pmix_bfrop_print_string(char **output, char *prefix, char *src, pm
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src);
+    if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -134,19 +162,28 @@ pmix_status_t pmix_bfrop_print_size(char **output, char *prefix, size_t *src, pm
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -159,19 +196,28 @@ pmix_status_t pmix_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -183,19 +229,28 @@ pmix_status_t pmix_bfrop_print_int(char **output, char *prefix, int *src, pmix_d
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -208,19 +263,28 @@ pmix_status_t pmix_bfrop_print_uint(char **output, char *prefix, uint *src, pmix
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -233,19 +297,28 @@ pmix_status_t pmix_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, 
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -258,19 +331,28 @@ pmix_status_t pmix_bfrop_print_uint16(char **output, char *prefix, uint16_t *src
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -284,19 +366,28 @@ pmix_status_t pmix_bfrop_print_uint32(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -310,19 +401,28 @@ pmix_status_t pmix_bfrop_print_int8(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -336,19 +436,28 @@ pmix_status_t pmix_bfrop_print_int16(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -361,19 +470,28 @@ pmix_status_t pmix_bfrop_print_int32(char **output, char *prefix, int32_t *src, 
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -387,19 +505,28 @@ pmix_status_t pmix_bfrop_print_uint64(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -414,19 +541,28 @@ pmix_status_t pmix_bfrop_print_int64(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -440,19 +576,28 @@ pmix_status_t pmix_bfrop_print_float(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src);
+    if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -466,19 +611,28 @@ pmix_status_t pmix_bfrop_print_double(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src);
+    if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -493,12 +647,19 @@ pmix_status_t pmix_bfrop_print_time(char **output, char *prefix,
     char *t;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
@@ -508,7 +669,9 @@ pmix_status_t pmix_bfrop_print_time(char **output, char *prefix,
     t = ctime(src);
     t[strlen(t)-1] = '\0';  // remove trailing newline
 
-    asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t);
+    if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -522,20 +685,29 @@ pmix_status_t pmix_bfrop_print_timeval(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
-             (long)src->tv_sec, (long)src->tv_usec);
+    if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+                    (long)src->tv_sec, (long)src->tv_usec)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -552,14 +724,22 @@ pmix_status_t pmix_bfrop_print_value(char **output, char *prefix,
                            pmix_value_t *src, pmix_data_type_t type)
 {
     char *prefx;
+    int rc;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
@@ -567,80 +747,84 @@ pmix_status_t pmix_bfrop_print_value(char **output, char *prefix,
     }
 
     switch (src->type) {
-    case PMIX_BYTE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x",
-                 prefx, src->data.byte);
+        case PMIX_BYTE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x",
+                      prefx, src->data.byte);
         break;
-    case PMIX_STRING:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s",
-                 prefx, src->data.string);
+        case PMIX_STRING:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s",
+                      prefx, src->data.string);
         break;
-    case PMIX_SIZE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu",
-                 prefx, (unsigned long)src->data.size);
+        case PMIX_SIZE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu",
+                      prefx, (unsigned long)src->data.size);
         break;
-    case PMIX_PID:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu",
-                 prefx, (unsigned long)src->data.pid);
+        case PMIX_PID:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu",
+                      prefx, (unsigned long)src->data.pid);
         break;
-    case PMIX_INT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d",
-                 prefx, src->data.integer);
+        case PMIX_INT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d",
+                      prefx, src->data.integer);
         break;
-    case PMIX_INT8:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d",
-                 prefx, (int)src->data.int8);
+        case PMIX_INT8:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d",
+                      prefx, (int)src->data.int8);
         break;
-    case PMIX_INT16:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d",
-                 prefx, (int)src->data.int16);
+        case PMIX_INT16:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d",
+                      prefx, (int)src->data.int16);
         break;
-    case PMIX_INT32:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d",
-                 prefx, src->data.int32);
+        case PMIX_INT32:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d",
+                      prefx, src->data.int32);
         break;
-    case PMIX_INT64:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld",
-                 prefx, (long)src->data.int64);
+        case PMIX_INT64:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld",
+                      prefx, (long)src->data.int64);
         break;
-    case PMIX_UINT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u",
-                 prefx, src->data.uint);
+        case PMIX_UINT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u",
+                      prefx, src->data.uint);
         break;
-    case PMIX_UINT8:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u",
-                 prefx, (unsigned int)src->data.uint8);
+        case PMIX_UINT8:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u",
+                      prefx, (unsigned int)src->data.uint8);
         break;
-    case PMIX_UINT16:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u",
-                 prefx, (unsigned int)src->data.uint16);
+        case PMIX_UINT16:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u",
+                      prefx, (unsigned int)src->data.uint16);
         break;
-    case PMIX_UINT32:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u",
-                 prefx, src->data.uint32);
+        case PMIX_UINT32:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u",
+                      prefx, src->data.uint32);
         break;
-    case PMIX_UINT64:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu",
-                 prefx, (unsigned long)src->data.uint64);
+        case PMIX_UINT64:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu",
+                      prefx, (unsigned long)src->data.uint64);
         break;
-    case PMIX_FLOAT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f",
-                 prefx, src->data.fval);
+        case PMIX_FLOAT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f",
+                      prefx, src->data.fval);
         break;
-    case PMIX_DOUBLE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f",
-                 prefx, src->data.dval);
+        case PMIX_DOUBLE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f",
+                      prefx, src->data.dval);
         break;
-    case PMIX_TIMEVAL:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
-                 (long)src->data.tv.tv_sec, (long)src->data.tv.tv_usec);
+        case PMIX_TIMEVAL:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+                     (long)src->data.tv.tv_sec, (long)src->data.tv.tv_usec);
         break;
-    default:
-        asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
+
+        default:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;
     }
     if (prefx != prefix) {
         free(prefx);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
     }
     return PMIX_SUCCESS;
 }
@@ -649,12 +833,16 @@ pmix_status_t pmix_bfrop_print_info(char **output, char *prefix,
                           pmix_info_t *src, pmix_data_type_t type)
 {
     char *tmp;
+    int rc;
 
     pmix_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    asprintf(output, "%sKEY: %s %s", prefix, src->key,
-             (NULL == tmp) ? "NULL" : tmp);
+    rc = asprintf(output, "%sKEY: %s %s", prefix, src->key,
+                  (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
     if (NULL != tmp) {
         free(tmp);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
     }
     return PMIX_SUCCESS;
 }
@@ -663,16 +851,20 @@ pmix_status_t pmix_bfrop_print_pdata(char **output, char *prefix,
                           pmix_pdata_t *src, pmix_data_type_t type)
 {
     char *tmp1, *tmp2;
+    int rc;
 
     pmix_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
     pmix_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
-    asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
-             (NULL == tmp2) ? "NULL" : tmp2);
+    rc = asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
+                 (NULL == tmp2) ? "NULL" : tmp2);
     if (NULL != tmp1) {
         free(tmp1);
     }
     if (NULL != tmp2) {
         free(tmp2);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
     }
     return PMIX_SUCCESS;
 }
@@ -695,10 +887,17 @@ pmix_status_t pmix_bfrop_print_proc(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
-    asprintf(output, "%sPROC: %s:%d", prefx, src->nspace, src->rank);
+    if (0 > asprintf(output, "%sPROC: %s:%d", prefx, src->nspace, src->rank)) {
+        return PMIX_ERR_NOMEM;
+    }
     return PMIX_SUCCESS;
 }
 
@@ -715,13 +914,22 @@ pmix_status_t pmix_bfrop_print_array(char **output, char *prefix,
     char *tmp, *tmp2, *tmp3, *pfx;
     pmix_info_t *s1;
 
-    asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size);
-    asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix);
+    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (0 > asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix)) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
     s1 = (pmix_info_t*)src->array;
 
     for (j=0; j < src->size; j++) {
         pmix_bfrop_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        asprintf(&tmp3, "%s%s", tmp, tmp2);
+        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+            free(tmp);
+            free(tmp2);
+            return PMIX_ERR_NOMEM;
+        }
         free(tmp);
         free(tmp2);
         tmp = tmp3;
@@ -743,13 +951,22 @@ static void print_hwloc_obj(char **output, char *prefix,
 
     /* print the object type */
     hwloc_obj_type_snprintf(string, 1024, obj, 1);
-    asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix);
-    asprintf(&tmp, "%sType: %s Number of child objects: %u%sName=%s",
-             (NULL == prefix) ? "" : prefix, string, obj->arity,
-             pfx, (NULL == obj->name) ? "NULL" : obj->name);
+    if (0 > asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix)) {
+        return;
+    }
+    if (0 > asprintf(&tmp, "%sType: %s Number of child objects: %u%sName=%s",
+                    (NULL == prefix) ? "" : prefix, string, obj->arity,
+                    pfx, (NULL == obj->name) ? "NULL" : obj->name)) {
+        free(pfx);
+        return;
+    }
     if (0 < hwloc_obj_attr_snprintf(string, 1024, obj, pfx, 1)) {
         /* print the attributes */
-        asprintf(&tmp2, "%s%s%s", tmp, pfx, string);
+        if (0 > asprintf(&tmp2, "%s%s%s", tmp, pfx, string)) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
     }
@@ -758,40 +975,65 @@ static void print_hwloc_obj(char **output, char *prefix,
      */
     if (NULL != obj->cpuset) {
         hwloc_bitmap_snprintf(string, PMIX_HWLOC_MAX_STRING, obj->cpuset);
-        asprintf(&tmp2, "%s%sCpuset:  %s", tmp, pfx, string);
+        if (0 > asprintf(&tmp2, "%s%sCpuset:  %s", tmp, pfx, string)) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
     }
     if (NULL != obj->online_cpuset) {
         hwloc_bitmap_snprintf(string, PMIX_HWLOC_MAX_STRING, obj->online_cpuset);
-        asprintf(&tmp2, "%s%sOnline:  %s", tmp, pfx, string);
+        if (0 > asprintf(&tmp2, "%s%sOnline:  %s", tmp, pfx, string)) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
     }
     if (NULL != obj->allowed_cpuset) {
         hwloc_bitmap_snprintf(string, PMIX_HWLOC_MAX_STRING, obj->allowed_cpuset);
-        asprintf(&tmp2, "%s%sAllowed: %s", tmp, pfx, string);
+        if (0 > asprintf(&tmp2, "%s%sAllowed: %s", tmp, pfx, string)) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
     }
     if (HWLOC_OBJ_MACHINE == obj->type) {
         /* root level object - add support values */
         support = (struct hwloc_topology_support*)hwloc_topology_get_support(topo);
-        asprintf(&tmp2, "%s%sBind CPU proc:   %s%sBind CPU thread: %s", tmp, pfx,
-                 (support->cpubind->set_thisproc_cpubind) ? "TRUE" : "FALSE", pfx,
-                 (support->cpubind->set_thisthread_cpubind) ? "TRUE" : "FALSE");
+        if (0 > asprintf(&tmp2, "%s%sBind CPU proc:   %s%sBind CPU thread: %s", tmp, pfx,
+                        (support->cpubind->set_thisproc_cpubind) ? "TRUE" : "FALSE", pfx,
+                        (support->cpubind->set_thisthread_cpubind) ? "TRUE" : "FALSE")) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
-        asprintf(&tmp2, "%s%sBind MEM proc:   %s%sBind MEM thread: %s", tmp, pfx,
-                 (support->membind->set_thisproc_membind) ? "TRUE" : "FALSE", pfx,
-                 (support->membind->set_thisthread_membind) ? "TRUE" : "FALSE");
+        if (0 > asprintf(&tmp2, "%s%sBind MEM proc:   %s%sBind MEM thread: %s", tmp, pfx,
+                        (support->membind->set_thisproc_membind) ? "TRUE" : "FALSE", pfx,
+                        (support->membind->set_thisthread_membind) ? "TRUE" : "FALSE")) {
+            free(tmp);
+            free(pfx);
+            return;
+        }
         free(tmp);
         tmp = tmp2;
     }
-    asprintf(&tmp2, "%s%s\n", (NULL == *output) ? "" : *output, tmp);
+    if (0 > asprintf(&tmp2, "%s%s\n", (NULL == *output) ? "" : *output, tmp)) {
+        free(tmp);
+        return;
+    }
     free(tmp);
     free(pfx);
-    asprintf(&pfx, "%s\t", (NULL == prefix) ? "" : prefix);
+    if (0 > asprintf(&pfx, "%s\t", (NULL == prefix) ? "" : prefix)) {
+        return;
+    }
     for (i=0; i < obj->arity; i++) {
         obj2 = obj->children[i];
         /* print the object */
@@ -831,19 +1073,28 @@ pmix_status_t pmix_bfrop_print_persist(char **output, char *prefix, pmix_persist
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src);
+    if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }
@@ -852,24 +1103,33 @@ pmix_status_t pmix_bfrop_print_persist(char **output, char *prefix, pmix_persist
 }
 
 pmix_status_t pmix_bfrop_print_bo(char **output, char *prefix,
-                        pmix_byte_object_t *src, pmix_data_type_t type)
+                                  pmix_byte_object_t *src, pmix_data_type_t type)
 {
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
-        asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx);
+        if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
         if (prefx != prefix) {
             free(prefx);
         }
         return PMIX_SUCCESS;
     }
 
-    asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long)src->size);
+    if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
     if (prefx != prefix) {
         free(prefx);
     }

--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -648,7 +648,9 @@ PMIX_EXPORT int PMI_Spawn_multiple(int count,
         }
         /* push the preput values into the apps environ */
         for (k = 0; k < preput_keyval_size; k++) {
-            (void)asprintf(&evar, "%s=%s", preput_keyval_vector[k].key, preput_keyval_vector[k].val);
+            if (0 > asprintf(&evar, "%s=%s", preput_keyval_vector[k].key, preput_keyval_vector[k].val)) {
+                return PMIX_ERR_NOMEM;
+            }
             pmix_argv_append_nosize(&apps[i].env, evar);
             free(evar);
         }

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -199,7 +199,9 @@ PMIX_EXPORT int PMI2_Job_Spawn(int count, const char * cmds[],
         }
         /* push the preput values into the apps environ */
         for (k=0; k < preput_keyval_size; k++) {
-            (void)asprintf(&evar, "%s=%s", preput_keyval_vector[j]->key, preput_keyval_vector[j]->val);
+            if (0 > asprintf(&evar, "%s=%s", preput_keyval_vector[j]->key, preput_keyval_vector[j]->val)) {
+                return PMIX_ERR_NOMEM;
+            }
             pmix_argv_append_nosize(&apps[i].env, evar);
             free(evar);
         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -219,7 +219,9 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     /* now set the address - we use the pid here to reduce collisions */
     memset(&myaddress, 0, sizeof(struct sockaddr_un));
     myaddress.sun_family = AF_UNIX;
-    asprintf(&pmix_pid, "pmix-%d", pid);
+    if (0 > asprintf(&pmix_pid, "pmix-%d", pid)) {
+        return PMIX_ERR_NOMEM;
+    }
     // If the above set temporary directory name plus the pmix-PID string
     // plus the '/' separator are too long, just fail, so the caller
     // may provide the user with a proper help... *Cough*, *Cough* OSX...
@@ -229,7 +231,10 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     }
     snprintf(myaddress.sun_path, sizeof(myaddress.sun_path)-1, "%s/%s", tdir, pmix_pid);
     free(pmix_pid);
-    asprintf(&myuri, "%s:%lu:%s", pmix_globals.myid.nspace, (unsigned long)pmix_globals.myid.rank, myaddress.sun_path);
+    if (0 > asprintf(&myuri, "%s:%lu:%s", pmix_globals.myid.nspace,
+                     (unsigned long)pmix_globals.myid.rank, myaddress.sun_path)) {
+        return PMIX_ERR_NOMEM;
+    }
 
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -1576,7 +1581,9 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
         if (0 == pmix_list_get_size(&vreg->ranges)) {
             if (NULL != vreg->prefix) {
                 /* solitary value */
-                asprintf(&tmp, "%s", vreg->prefix);
+                if (0 > asprintf(&tmp, "%s", vreg->prefix)) {
+                    return PMIX_ERR_NOMEM;
+                }
                 pmix_argv_append_nosize(&regexargs, tmp);
                 free(tmp);
             }
@@ -1585,16 +1592,24 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
         }
         /* start the regex for this value with the prefix */
         if (NULL != vreg->prefix) {
-            asprintf(&tmp, "%s[%d:", vreg->prefix, vreg->num_digits);
+            if (0 > asprintf(&tmp, "%s[%d:", vreg->prefix, vreg->num_digits)) {
+                return PMIX_ERR_NOMEM;
+            }
         } else {
-            asprintf(&tmp, "[%d:", vreg->num_digits);
+            if (0 > asprintf(&tmp, "[%d:", vreg->num_digits)) {
+                return PMIX_ERR_NOMEM;
+            }
         }
         /* add the ranges */
         while (NULL != (range = (pmix_regex_range_t*)pmix_list_remove_first(&vreg->ranges))) {
             if (1 == range->cnt) {
-                asprintf(&tmp2, "%s%d,", tmp, range->start);
+                if (0 > asprintf(&tmp2, "%s%d,", tmp, range->start)) {
+                    return PMIX_ERR_NOMEM;
+                }
             } else {
-                asprintf(&tmp2, "%s%d-%d,", tmp, range->start, range->start + range->cnt - 1);
+                if (0 > asprintf(&tmp2, "%s%d-%d,", tmp, range->start, range->start + range->cnt - 1)) {
+                    return PMIX_ERR_NOMEM;
+                }
             }
             free(tmp);
             tmp = tmp2;
@@ -1604,7 +1619,9 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
         tmp[strlen(tmp)-1] = ']';
         if (NULL != vreg->suffix) {
             /* add in the suffix, if provided */
-            asprintf(&tmp2, "%s%s", tmp, vreg->suffix);
+            if (0 > asprintf(&tmp2, "%s%s", tmp, vreg->suffix)) {
+                return PMIX_ERR_NOMEM;
+            }
             free(tmp);
             tmp = tmp2;
         }
@@ -1615,7 +1632,9 @@ PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
 
     /* assemble final result */
     tmp = pmix_argv_join(regexargs, ',');
-    asprintf(regexp, "pmix[%s]", tmp);
+    if (0 > asprintf(regexp, "pmix[%s]", tmp)) {
+        return PMIX_ERR_NOMEM;
+    }
     free(tmp);
 
     /* cleanup */
@@ -1716,9 +1735,13 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
     PMIX_LIST_FOREACH(vreg, &nodes, pmix_regex_value_t) {
         while (NULL != (rng = (pmix_regex_range_t*)pmix_list_remove_first(&vreg->ranges))) {
             if (1 == rng->cnt) {
-                asprintf(&tmp2, "%s%d,", tmp, rng->start);
+                if (0 > asprintf(&tmp2, "%s%d,", tmp, rng->start)) {
+                    return PMIX_ERR_NOMEM;
+                }
             } else {
-                asprintf(&tmp2, "%s%d-%d,", tmp, rng->start, rng->start + rng->cnt - 1);
+                if (0 > asprintf(&tmp2, "%s%d-%d,", tmp, rng->start, rng->start + rng->cnt - 1)) {
+                    return PMIX_ERR_NOMEM;
+                }
             }
             free(tmp);
             tmp = tmp2;

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -187,7 +187,9 @@ void pmix_stop_listening(void)
      * case the thread is blocked in a call to select for
      * a long time */
     i=1;
-    write(pmix_server_globals.stop_thread[1], &i, sizeof(int));
+    if (0 > write(pmix_server_globals.stop_thread[1], &i, sizeof(int))) {
+        return;
+    }
     /* wait for thread to exit */
     pthread_join(engine, NULL);
     /* close the socket to remove the connection point */

--- a/src/server/pmix_server_regex.c
+++ b/src/server/pmix_server_regex.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -528,7 +528,9 @@ static pmix_status_t pmix_regex_extract_ppn(char *regexp, char ***procs)
                 ++t;
                 end = strtol(t, NULL, 10);
                 for (k=start; k <= end; k++) {
-                    asprintf(&t, "%d", k);
+                    if (0 > asprintf(&t, "%d", k)) {
+                        return PMIX_ERR_NOMEM;
+                    }
                     pmix_argv_append_nosize(&ps, t);
                     free(t);
                 }

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -103,11 +103,11 @@ char **pmix_environ_merge(char **minor, char **major)
     /* Make the new value */
 
     if (NULL == value) {
-        asprintf(&newvalue, "%s=", name);
+        i = asprintf(&newvalue, "%s=", name);
     } else {
-        asprintf(&newvalue, "%s=%s", name, value);
+        i = asprintf(&newvalue, "%s=%s", name, value);
     }
-    if (NULL == newvalue) {
+    if (NULL == newvalue || 0 > i) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
@@ -135,8 +135,8 @@ char **pmix_environ_merge(char **minor, char **major)
 
     /* Make something easy to compare to */
 
-    asprintf(&compare, "%s=", name);
-    if (NULL == compare) {
+    i = asprintf(&compare, "%s=", name);
+    if (NULL == compare || 0 > i) {
         free(newvalue);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
@@ -191,8 +191,8 @@ char **pmix_environ_merge(char **minor, char **major)
 
     /* Make something easy to compare to */
 
-    asprintf(&compare, "%s=", name);
-    if (NULL == compare) {
+    i = asprintf(&compare, "%s=", name);
+    if (NULL == compare || 0 > i) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
     len = strlen(compare);

--- a/src/util/progress_threads.c
+++ b/src/util/progress_threads.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -113,7 +113,9 @@ void pmix_stop_progress_thread(pmix_event_base_t *ev_base)
      * a long time */
     if (block_active) {
         i=1;
-        write(block_pipe[1], &i, sizeof(int));
+        if (0 > write(block_pipe[1], &i, sizeof(int))) {
+            return;
+        }
     }
     /* break the event loop - this will cause the loop to exit
      * upon completion of any current event */


### PR DESCRIPTION
(cherry picked from commit pmix/master@696e22119dedd902b0b090f2bff4045b3c8a8beb)

@garlick Could you please verify that this fixes things on the 1.1.4 branch?
