### PR TITLE
Per the telecon, remove the envar method for passing the tmpdir

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -95,6 +95,8 @@ BEGIN_C_DECLS
 
 /* attributes for the rendezvous socket  */
 #define PMIX_SOCKET_MODE           "pmix.sockmode"          // (uint32_t) POSIX mode_t (9 bits valid)
+#define PMIX_SERVER_TMPDIR         "pmix.srvr.tmpdir"       // (char*) temp directory where PMIx server will place
+                                                            //         client rendezvous points
 
 /* general proc-level attributes */
 #define PMIX_CPUSET                "pmix.cpuset"            // (char*) hwloc bitmap applied to proc upon launch


### PR DESCRIPTION
Per the telecon, remove the envar method for passing the tmpdir to be used by the PMIx server and replace it with an info key method. We will standardize on the info key method going forward.